### PR TITLE
Add, fix and improve licenses

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -30,12 +30,15 @@ pub const FILE_EXTENSION_COLORS: &[(&[&str], (u8, u8, u8))] = &[
 // https://choosealicense.com/
 pub const LICENSES: &[(&str, &str)] = &[
   ("MIT", "MIT License"),
+  ("MIT-0", "MIT No Attribution License"),
   ("GPLv3", "GNU GENERAL PUBLIC LICENSE\nVersion 3"),
   ("GPLv2", "GNU GENERAL PUBLIC LICENSE\nVersion 2"),
+  ("LGPLv2.1", "GNU LESSER GENERAL PUBLIC LICENSE\n Version 2.1")
   ("LGPLv3", "GNU LESSER GENERAL PUBLIC LICENSE\nVersion 3"),
   ("AGPLv3", "GNU AFFERO GENERAL PUBLIC LICENSE\nVersion 3"),
   ("Mozilla Public License 2.0", "Mozilla Public License Version 2.0"),
   ("Apache License 2.0", "Apache License\nVersion 2.0"),
+  ("APSL-2.0", "Apple Public Source License"),
   ("BSL-1.0", "Boost Software License - Version 1.0"),
   ("The Unlicense", "This is free and unencumbered software released into the public domain."),
 ];

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -36,7 +36,7 @@ pub const LICENSES: &[(&str, &str)] = &[
   ("AGPLv3", "GNU AFFERO GENERAL PUBLIC LICENSE\nVersion 3"),
   ("Mozilla Public License 2.0", "Mozilla Public License Version 2.0"),
   ("Apache License 2.0", "Apache License\nVersion 2.0"),
-  ("Boost Software License 1.0", "Boost Software License - Version 1.0"),
+  ("BSL-1.0", "Boost Software License - Version 1.0"),
   ("The Unlicense", "This is free and unencumbered software released into the public domain."),
 ];
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -32,18 +32,18 @@ pub const FILE_EXTENSION_COLORS: &[(&[&str], (u8, u8, u8))] = &[
 pub const LICENSES: &[(&str, &str)] = &[
   ("MIT", "MIT License"),
   ("MIT-0", "MIT No Attribution License"),
-  ("GPLv3", "GNU GENERAL PUBLIC LICENSE\nVersion 3"),
-  ("GPLv2", "GNU GENERAL PUBLIC LICENSE\nVersion 2"),
-  ("LGPLv2.1", "GNU LESSER GENERAL PUBLIC LICENSE\n Version 2.1")
-  ("LGPLv3", "GNU LESSER GENERAL PUBLIC LICENSE\nVersion 3"),
-  ("AGPLv3", "GNU AFFERO GENERAL PUBLIC LICENSE\nVersion 3"),
-  ("Mozilla Public License 2.0", "Mozilla Public License Version 2.0"),
-  ("Apache License 2.0", "Apache License\nVersion 2.0"),
+  ("GPL-3.0", "GNU GENERAL PUBLIC LICENSE\nVersion 3"),
+  ("GPL-2.0", "GNU GENERAL PUBLIC LICENSE\nVersion 2"),
+  ("LGPL-2.1", "GNU LESSER GENERAL PUBLIC LICENSE\n Version 2.1")
+  ("LGPL-3.0", "GNU LESSER GENERAL PUBLIC LICENSE\nVersion 3"),
+  ("AGPL-3.0", "GNU AFFERO GENERAL PUBLIC LICENSE\nVersion 3"),
+  ("MPL-2.0", "Mozilla Public License Version 2.0"),
+  ("Apache-2.0", "Apache License\nVersion 2.0"),
   ("AFL-3.0", "Academic Free License 3.0"),
   ("APSL-2.0", "Apple Public Source License"),
   ("APL-1.0", "Adaptive Public License 1.0"),
   ("BSL-1.0", "Boost Software License - Version 1.0"),
-  ("The Unlicense", "This is free and unencumbered software released into the public domain."),
+  ("Unlicense", "This is free and unencumbered software released into the public domain."),
 ];
 
 pub const COLLAPSED_DIRECTORIES: &[&str] = &[

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -11,7 +11,7 @@ pub const FILE_EXTENSION_COLORS: &[(&[&str], (u8, u8, u8))] = &[
   (&["cs"], (23, 134, 0)),                  // C#
   (&["rb"], (112, 21, 22)),                 // Ruby
   (&["pl"], (2, 152, 195)),                 // Pearl
-  (&["swift"], (255, 172, 69)),             // Switft
+  (&["swift"], (255, 172, 69)),             // Swift
   (&["md", "markdown"], (8, 63, 161)),      // Markdown
   (&["py"], (53, 114, 165)),                // Python
   (&["html", "htm"], (227, 76, 38)),        // HTML

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -28,6 +28,7 @@ pub const FILE_EXTENSION_COLORS: &[(&[&str], (u8, u8, u8))] = &[
 ];
 
 // https://choosealicense.com/
+// https://opensource.org/licenses/
 pub const LICENSES: &[(&str, &str)] = &[
   ("MIT", "MIT License"),
   ("MIT-0", "MIT No Attribution License"),

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -29,6 +29,7 @@ pub const FILE_EXTENSION_COLORS: &[(&[&str], (u8, u8, u8))] = &[
 
 // https://choosealicense.com/
 // https://opensource.org/licenses/
+// https://spdx.org/licenses/
 pub const LICENSES: &[(&str, &str)] = &[
   ("MIT", "MIT License"),
   ("MIT-0", "MIT No Attribution"),

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -31,17 +31,18 @@ pub const FILE_EXTENSION_COLORS: &[(&[&str], (u8, u8, u8))] = &[
 // https://opensource.org/licenses/
 pub const LICENSES: &[(&str, &str)] = &[
   ("MIT", "MIT License"),
-  ("MIT-0", "MIT No Attribution License"),
+  ("MIT-0", "MIT No Attribution"),
   ("GPL-3.0", "GNU GENERAL PUBLIC LICENSE\nVersion 3"),
   ("GPL-2.0", "GNU GENERAL PUBLIC LICENSE\nVersion 2"),
-  ("LGPL-2.1", "GNU LESSER GENERAL PUBLIC LICENSE\n Version 2.1"),
+  ("LGPL-2.1", "GNU LESSER GENERAL PUBLIC LICENSE\nVersion 2.1"),
   ("LGPL-3.0", "GNU LESSER GENERAL PUBLIC LICENSE\nVersion 3"),
   ("AGPL-3.0", "GNU AFFERO GENERAL PUBLIC LICENSE\nVersion 3"),
   ("MPL-2.0", "Mozilla Public License Version 2.0"),
   ("Apache-2.0", "Apache License\nVersion 2.0"),
-  ("AFL-3.0", "Academic Free License 3.0"),
-  ("APSL-2.0", "Apple Public Source License"),
-  ("APL-1.0", "Adaptive Public License 1.0"),
+  ("AFL-3.0", "Academic Free License (\"AFL\") v. 3.0"),
+  ("APSL-1.0", "APPLE PUBLIC SOURCE LICENSE\nVersion 1.0"),
+  ("APL-2.0", "APPLE PUBLIC SOURCE LICENSE\nVersion 2.0"),
+  ("APL-1.0", "ADAPTIVE PUBLIC LICENSE\nVersion 1.0"),
   ("BSL-1.0", "Boost Software License - Version 1.0"),
   ("Unlicense", "This is free and unencumbered software released into the public domain."),
 ];

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -39,7 +39,9 @@ pub const LICENSES: &[(&str, &str)] = &[
   ("AGPLv3", "GNU AFFERO GENERAL PUBLIC LICENSE\nVersion 3"),
   ("Mozilla Public License 2.0", "Mozilla Public License Version 2.0"),
   ("Apache License 2.0", "Apache License\nVersion 2.0"),
+  ("AFL-3.0", "Academic Free License 3.0"),
   ("APSL-2.0", "Apple Public Source License"),
+  ("APL-1.0", "Adaptive Public License 1.0"),
   ("BSL-1.0", "Boost Software License - Version 1.0"),
   ("The Unlicense", "This is free and unencumbered software released into the public domain."),
 ];

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -31,20 +31,20 @@ pub const FILE_EXTENSION_COLORS: &[(&[&str], (u8, u8, u8))] = &[
 // https://opensource.org/licenses/
 // https://spdx.org/licenses/
 pub const LICENSES: &[(&str, &str)] = &[
-  ("MIT", "MIT License"),
-  ("MIT-0", "MIT No Attribution"),
-  ("GPL-3.0", "GNU GENERAL PUBLIC LICENSE\nVersion 3"),
+  ("AFL-3.0", "Academic Free License (\"AFL\") v. 3.0"),
+  ("AGPL-3.0", "GNU AFFERO GENERAL PUBLIC LICENSE\nVersion 3"),
+  ("Apache-2.0", "Apache License\nVersion 2.0"),
+  ("APL-1.0", "ADAPTIVE PUBLIC LICENSE\nVersion 1.0"),
+  ("APSL-1.0", "APPLE PUBLIC SOURCE LICENSE\nVersion 1.0"),
+  ("APSL-2.0", "APPLE PUBLIC SOURCE LICENSE\nVersion 2.0"),
+  ("BSL-1.0", "Boost Software License - Version 1.0"),
   ("GPL-2.0", "GNU GENERAL PUBLIC LICENSE\nVersion 2"),
+  ("GPL-3.0", "GNU GENERAL PUBLIC LICENSE\nVersion 3"),
   ("LGPL-2.1", "GNU LESSER GENERAL PUBLIC LICENSE\nVersion 2.1"),
   ("LGPL-3.0", "GNU LESSER GENERAL PUBLIC LICENSE\nVersion 3"),
-  ("AGPL-3.0", "GNU AFFERO GENERAL PUBLIC LICENSE\nVersion 3"),
+  ("MIT", "MIT License"),
+  ("MIT-0", "MIT No Attribution"),
   ("MPL-2.0", "Mozilla Public License Version 2.0"),
-  ("Apache-2.0", "Apache License\nVersion 2.0"),
-  ("AFL-3.0", "Academic Free License (\"AFL\") v. 3.0"),
-  ("APSL-1.0", "APPLE PUBLIC SOURCE LICENSE\nVersion 1.0"),
-  ("APL-2.0", "APPLE PUBLIC SOURCE LICENSE\nVersion 2.0"),
-  ("APL-1.0", "ADAPTIVE PUBLIC LICENSE\nVersion 1.0"),
-  ("BSL-1.0", "Boost Software License - Version 1.0"),
   ("Unlicense", "This is free and unencumbered software released into the public domain."),
 ];
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -34,7 +34,7 @@ pub const LICENSES: &[(&str, &str)] = &[
   ("MIT-0", "MIT No Attribution License"),
   ("GPL-3.0", "GNU GENERAL PUBLIC LICENSE\nVersion 3"),
   ("GPL-2.0", "GNU GENERAL PUBLIC LICENSE\nVersion 2"),
-  ("LGPL-2.1", "GNU LESSER GENERAL PUBLIC LICENSE\n Version 2.1")
+  ("LGPL-2.1", "GNU LESSER GENERAL PUBLIC LICENSE\n Version 2.1"),
   ("LGPL-3.0", "GNU LESSER GENERAL PUBLIC LICENSE\nVersion 3"),
   ("AGPL-3.0", "GNU AFFERO GENERAL PUBLIC LICENSE\nVersion 3"),
   ("MPL-2.0", "Mozilla Public License Version 2.0"),

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -30,6 +30,8 @@ pub const FILE_EXTENSION_COLORS: &[(&[&str], (u8, u8, u8))] = &[
 // https://choosealicense.com/
 // https://opensource.org/licenses/
 // https://spdx.org/licenses/
+// LICENSES LIST: ("SPDX identifier", "Start of the license file/text")
+//  Licenses are ordered alphabetically based on their SPDX identifier
 pub const LICENSES: &[(&str, &str)] = &[
   ("AFL-3.0", "Academic Free License (\"AFL\") v. 3.0"),
   ("AGPL-3.0", "GNU AFFERO GENERAL PUBLIC LICENSE\nVersion 3"),


### PR DESCRIPTION
### What was done?

This PR is the first of many PRs about licenses. This first one adds many licenses, reorders them, makes the switch to SPDX identifiers and fixes some other issues.

Other than licenses, a small typo was fixed in the colors of file extensions, specifically in the Swift language.

### New license naming standard

The way licenses are registered is now as discussed in issue #27. They are now identified by their corresponding SPDX identifier, that is the first string in a license item in the list. They have also been reordered, following an alphabetical order based on the SPDX identifier.

### Licenses added

Below are listed the licenses added in this PR, more are to be added in other PRs.

- **APSL-2.0**: 
- **MIT-0**:
- **LGPL-2.1**:
- **AFL-3.0**:
- **APL-1.0**:
- **AFL-3.0**:

*By any means this list is complete, and more work will be put into license registration in the future.*

### Issues related

Resolves #27 and contributes to #7.

### Documentation on licenses

The sources used for the expansion of the list are cited as comments below the choosealicense.com one. These sources are the Open Source Initiative (for licenses and their SPDX identifiers) and the official SPDX webpage (for the full license text).

In addition to the sources, two lien comments have been added. These comments simply add a little bit of documentation about how the LICENSE list is structured, stating how it is ordered and what each string means. These comments were put in place to help future contributors better understand how to contribute to this license.