### PR TITLE
Single file printing

### DIFF
--- a/lsfp-installer.sh
+++ b/lsfp-installer.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+# The present file is a command line utility for installing, updating and remove lsfp.
+# It is provided with the same license as the project, a MIT license.
+
+print_help()
+{
+  echo This is a help message
+}
+
+install()
+{
+  if [ ! -z "`which curl`" ]; then
+    echo "Proceeding to download binary with curl"
+  elif [ ! -z "`which wget`" ]; then
+    echo "Proceeding to download binary with wget"
+  else
+    echo "Neither curl nor wget were found in the device, please install at least one of them"
+  fi
+  # Allow to choose lite or complete, give possibility of creating alias for ls
+}
+
+update()
+{
+  if [ -z "${LSFP_VERSION}" ]; then
+    echo "It seems like lsfp has never been installed here, please run 'lsfp-installer install'"
+    exit 1
+  fi
+  version=${LSFP_VERSION}
+  echo "To update from ${version} to latest"
+}
+
+features()
+{
+  # features=$LSFP_FEATURES(=10 or 11 or 01 or 00)
+  echo "Get ready to change the features of your lsfp installation"
+}
+
+remove()
+{
+  echo "Unsetting environment variables and removing binary from `basename $0`"
+}
+
+if [ -z "$1" ]; then
+  print_help
+else
+  case "$1" in
+    "install")
+      install
+      ;;
+    "update")
+      update
+      ;;
+    "features")
+      features
+      ;;
+    "remove")
+      remove
+    ;;
+    *)
+      echo "The command you typed does not exist" && echo
+      if [ "$1" = "instal" -o "$1" = "installl" -o "$1" = "istall" -o "$1" = "imstall" -o "$1" = "i" ]; then
+        echo "Did you mean 'install'?"
+      fi
+  esac
+fi

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,8 +18,8 @@ extern "C" {
   fn enable_color();
 }
 
-fn print_item(root: &path::Path, path: path::PathBuf, flags: &args::Flags) {
-  if !flags.all && file_detection::is_hidden(&path) {
+fn print_item(root: &path::Path, path: path::PathBuf, flags: &args::Flags, single_item: bool) {
+  if !flags.all && file_detection::is_hidden(&path) && !single_item {
     return;
   }
   #[cfg(feature = "color")]
@@ -120,7 +120,7 @@ fn do_scan(root: &path::Path, path_to_scan: &path::Path, flags: &args::Flags) {
 
   if path_to_scan.is_file() {
     let path = path::PathBuf::from(path_to_scan);
-    print_item(root, path, flags);
+    print_item(root, path, flags, false);
   } else {
     if !flags.all && constants::COLLAPSED_DIRECTORIES.contains(&item_name) {
       return;
@@ -129,7 +129,7 @@ fn do_scan(root: &path::Path, path_to_scan: &path::Path, flags: &args::Flags) {
     for entry in fs::read_dir(path_to_scan).unwrap() {
       let path = entry.unwrap().path();
 
-      print_item(root, path.clone(), flags);
+      print_item(root, path.clone(), flags, false);
 
       if path.is_dir() {
         do_scan(root, path.as_path(), flags);
@@ -158,7 +158,7 @@ fn main() {
   }
 
   if path_to_scan.is_file() {
-    print_item(path_to_scan, path::PathBuf::from(path_to_scan), &flags);
+    print_item(path_to_scan, path::PathBuf::from(path_to_scan), &flags, true); // Only situation where single_item will be true
   } else if flags.tree {
     do_scan(path_to_scan, path_to_scan, &flags);
   } else {
@@ -166,7 +166,7 @@ fn main() {
     if read_dir.is_ok() {
       for entry in read_dir.unwrap() {
         let path = entry.unwrap().path();
-        print_item(path_to_scan, path, &flags);
+        print_item(path_to_scan, path, &flags, false);
       }
     } else if read_dir.is_err() {
       println!(


### PR DESCRIPTION
### Changes to usage

Now, when running lsfp on a single file, it will always show up, be it a shown or hidden file. This pull request closes #31.

### Code changes

The code changed to make this work is pretty straightforward. A new argument has been added to the `print_item` function to check wether it is a single file what it is printing, leaving the function signature like the following:

```rust
21 | fn print_item(root: &path::Path, path: path::PathBuf, flags: &args::Flags, single_item: bool)
```

This new argument is then used in the conditional that checks if it is hidden, which now only turns out to be positive if that argument is set to false. The new conditional is as follows:

```rust
22 | if !flags.all && file_detection::is_hidden(&path) && !single_item {
```
