### PR TITLE
Improve error handling with new .die() method

### DIFF
--- a/src/core/args.rs
+++ b/src/core/args.rs
@@ -47,7 +47,7 @@ pub fn get() -> (Flags, Vec<String>) {
       "--no-git" => flags.no_git = true,
       #[cfg(feature = "config")]
       _ => {
-        if !config::parse_arg(arg) {
+        if !config::parse_arg(arg, &flags) {
           continue;
         }
       }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,9 +1,12 @@
 use std::fs;
 
+use crate::core::args::Flags;
+use crate::helper::Die;
+
 const CONFIG_NAME: &str = ".lsfprc";
 const ARG_PREFIX: &str = "--config-";
 
-pub fn parse_arg(arg: &str) -> bool {
+pub fn parse_arg(arg: &str, flags: &Flags) -> bool {
   if arg.starts_with(ARG_PREFIX) {
     let body = arg.strip_prefix(ARG_PREFIX).unwrap(); // strip argument prefix
 
@@ -16,7 +19,7 @@ pub fn parse_arg(arg: &str) -> bool {
       let content_split = match fs::read_to_string(CONFIG_NAME) {
         Ok(x) => x,
         Err(_) => {
-          fs::write(CONFIG_NAME, format!("- config: {}={}", name, value)).expect("unable to save config file");
+          fs::write(CONFIG_NAME, format!("- config: {}={}", name, value)).die("unable to save config file", flags);
           return true;
         }
       };
@@ -45,7 +48,7 @@ pub fn parse_arg(arg: &str) -> bool {
         contents.push(edited_line2.as_str());
       }
 
-      fs::write(CONFIG_NAME, contents.join("\n")).expect("unable to save config file");
+      fs::write(CONFIG_NAME, contents.join("\n")).die("unable to save config file", flags);
     } else {
       let contents = match fs::read_to_string(CONFIG_NAME) {
         Ok(x) => x,

--- a/src/file_detection.rs
+++ b/src/file_detection.rs
@@ -3,12 +3,14 @@ use std::fs;
 use std::path::Path;
 
 use crate::constants;
+use crate::core::args::Flags;
+use crate::helper::Die;
 
 #[cfg(target_os = "windows")]
 fn is_hidden_extra(path: &Path) -> bool {
   use std::os::windows::fs::MetadataExt;
 
-  let file_metadata = fs::metadata(path).expect("Failed getting metadata");
+  let file_metadata = fs::metadata(path).die("Failed getting metadata");
   let attribs = file_metadata.file_attributes();
 
   // https://docs.microsoft.com/en-us/dotnet/api/system.io.fileattributes?view=net-5.0#fields
@@ -20,14 +22,16 @@ fn is_hidden_extra(_path: &Path) -> bool {
   false
 }
 
-pub fn is_hidden(path: &Path) -> bool {
-  let item_name = OsStr::new(path.file_name().expect("Unable to get file name")).to_str().expect("Unable to parse file name");
+pub fn is_hidden(path: &Path, flags: &Flags) -> bool {
+  let item_name = OsStr::new(path.file_name().die("Unable to get file name", flags))
+    .to_str()
+    .die("Unable to parse file name", flags);
 
   item_name.starts_with('.') || is_hidden_extra(path)
 }
 
-pub fn get_license(path: &Path) -> String {
-  let mut contents = fs::read_to_string(path).expect("Failed reading license file");
+pub fn get_license(path: &Path, flags: &Flags) -> String {
+  let mut contents = fs::read_to_string(path).die("Failed reading license file", flags);
   contents = contents.replace("\r", "").trim().to_string();
 
   let mut final_contents = String::new();
@@ -46,12 +50,12 @@ pub fn get_license(path: &Path) -> String {
   license_type.to_string()
 }
 
-pub fn file_extension_color(path: &Path) -> String {
+pub fn file_extension_color(path: &Path, flags: &Flags) -> String {
   let mut color = String::new();
 
   'extension_loop: for extension_color in constants::FILE_EXTENSION_COLORS.iter() {
     for extension in extension_color.0 {
-      if extension_matches(path, extension) {
+      if extension_matches(path, extension, flags) {
         color = format!("\x1b[38;2;{};{};{}m", extension_color.1 .0, extension_color.1 .1, extension_color.1 .2);
         break 'extension_loop;
       }
@@ -61,9 +65,9 @@ pub fn file_extension_color(path: &Path) -> String {
   color
 }
 
-fn extension_matches(path: &Path, extension: &str) -> bool {
-  OsStr::new(path.extension().expect("Unable to get file extension"))
+fn extension_matches(path: &Path, extension: &str, flags: &Flags) -> bool {
+  OsStr::new(path.extension().die("Unable to get file extension", flags))
     .to_str()
-    .expect("Unable to parse file extension")
+    .die("Unable to parse file extension", flags)
     == extension
 }

--- a/src/file_detection.rs
+++ b/src/file_detection.rs
@@ -65,6 +65,6 @@ pub fn file_extension_color(path: &Path, flags: &Flags) -> String {
   color
 }
 
-fn extension_matches(path: &Path, extension: &str) -> bool {
-  path.extension().unwrap_or_else(|| OsStr::new("")).to_str().expect("Unable to parse file extension") == extension
+fn extension_matches(path: &Path, extension: &str, flags: &Flags) -> bool {
+  path.extension().unwrap_or_else(|| OsStr::new("")).to_str().die("Unable to parse file extension", flags) == extension
 }

--- a/src/file_detection.rs
+++ b/src/file_detection.rs
@@ -7,10 +7,10 @@ use crate::core::args::Flags;
 use crate::helper::Die;
 
 #[cfg(target_os = "windows")]
-fn is_hidden_extra(path: &Path) -> bool {
+fn is_hidden_extra(path: &Path, flags: &Flags) -> bool {
   use std::os::windows::fs::MetadataExt;
 
-  let file_metadata = fs::metadata(path).die("Failed getting metadata");
+  let file_metadata = fs::metadata(path).die("Failed getting metadata", flags);
   let attribs = file_metadata.file_attributes();
 
   // https://docs.microsoft.com/en-us/dotnet/api/system.io.fileattributes?view=net-5.0#fields
@@ -18,7 +18,7 @@ fn is_hidden_extra(path: &Path) -> bool {
 }
 
 #[cfg(not(target_os = "windows"))]
-fn is_hidden_extra(_path: &Path) -> bool {
+fn is_hidden_extra(_path: &Path, _flags: &Flags) -> bool {
   false
 }
 
@@ -27,7 +27,7 @@ pub fn is_hidden(path: &Path, flags: &Flags) -> bool {
     .to_str()
     .die("Unable to parse file name", flags);
 
-  item_name.starts_with('.') || is_hidden_extra(path)
+  item_name.starts_with('.') || is_hidden_extra(path, flags)
 }
 
 pub fn get_license(path: &Path, flags: &Flags) -> String {
@@ -65,6 +65,6 @@ pub fn file_extension_color(path: &Path, flags: &Flags) -> String {
   color
 }
 
-fn extension_matches(path: &Path, extension: &str) -> bool {
-  path.extension().unwrap_or(OsStr::new("")).to_str().expect("Unable to parse file extension") == extension
+fn extension_matches(path: &Path, extension: &str, flags: &Flags) -> bool {
+  path.extension().unwrap_or(OsStr::new("")).to_str().die("Unable to parse file extension", flags) == extension
 }

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,0 +1,40 @@
+#![allow(unused_imports)] // Rust raises a warning with the `use crate::color::ColorExt`, but it is actually used for color formatting error output
+#![allow(unused_variables)] // Rust complains with `msg` and `flags` not being used in the Die trait, but they are actually used in the trait's implementation
+
+use crate::color::ColorExt;
+use crate::core::args::Flags;
+
+pub trait Die<T> {
+  fn die(self, msg: &str, flags: &Flags) -> T;
+}
+
+impl<T, E> Die<T> for Result<T, E>
+where
+  E: std::fmt::Debug,
+{
+  fn die(self, msg: &str, flags: &Flags) -> T {
+    #[cfg(not(debug_assertions))]
+    if let Err(_) = self {
+      println!("{} {}", "ERROR".to_owned().red(flags).bright(flags).reset(flags), msg);
+      std::process::exit(1)
+    } else {
+      self.unwrap()
+    }
+    #[cfg(debug_assertions)]
+    self.expect(msg)
+  }
+}
+
+impl<T> Die<T> for Option<T> {
+  fn die(self, msg: &str, flags: &Flags) -> T {
+    #[cfg(not(debug_assertions))]
+    if let None = self {
+      println!("{} {}", "ERROR".to_owned().red(flags).bright(flags).reset(flags), msg);
+      std::process::exit(1)
+    } else {
+      self.unwrap()
+    }
+    #[cfg(debug_assertions)]
+    self.expect(msg)
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,11 +18,10 @@ extern "C" {
   fn enable_color();
 }
 
-fn print_item(root: &path::Path, path: path::PathBuf, flags: &args::Flags) {
-  if !flags.all && file_detection::is_hidden(&path) {
+fn print_item(root: &path::Path, path: path::PathBuf, flags: &args::Flags, single_item: bool) {
+  if !flags.all && file_detection::is_hidden(&path) && !single_item {
     return;
   }
-
   let mut color = if path.is_dir() { "".to_owned().cyan(flags) } else { "".to_owned() };
 
   let mut prefix = String::new();
@@ -111,7 +110,7 @@ fn do_scan(root: &path::Path, path_to_scan: &path::Path, flags: &args::Flags) {
 
   if path_to_scan.is_file() {
     let path = path::PathBuf::from(path_to_scan);
-    print_item(root, path, flags);
+    print_item(root, path, flags, false);
   } else {
     if !flags.all && constants::COLLAPSED_DIRECTORIES.contains(&item_name) {
       return;
@@ -120,7 +119,7 @@ fn do_scan(root: &path::Path, path_to_scan: &path::Path, flags: &args::Flags) {
     for entry in fs::read_dir(path_to_scan).expect("Directory cannot be accessed") {
       let path = entry.expect("Failed retrieving path").path();
 
-      print_item(root, path.clone(), flags);
+      print_item(root, path.clone(), flags, false);
 
       if path.is_dir() {
         do_scan(root, path.as_path(), flags);
@@ -149,13 +148,13 @@ fn main() {
   }
 
   if path_to_scan.is_file() {
-    print_item(path_to_scan, path::PathBuf::from(path_to_scan), &flags);
+    print_item(path_to_scan, path::PathBuf::from(path_to_scan), &flags, true); // Only situation where single_item will be true
   } else if flags.tree {
     do_scan(path_to_scan, path_to_scan, &flags);
   } else {
     for entry in fs::read_dir(path_to_scan).expect("Directory cannot be accessed") {
       let path = entry.expect("Failed retrieving path").path();
-      print_item(path_to_scan, path, &flags);
+      print_item(path_to_scan, path, &flags, false);
     }
   }
 }

--- a/src/modules/git.rs
+++ b/src/modules/git.rs
@@ -1,14 +1,17 @@
 use std::path;
 use std::process::Command;
 
-pub fn changed(file_path: &path::Path) -> bool {
+use crate::core::args::Flags;
+use crate::helper::Die;
+
+pub fn changed(file_path: &path::Path, flags: &Flags) -> bool {
   let result = Command::new("git").arg("status").arg("--porcelain").arg(file_path).output();
 
   if result.is_err() {
     return false;
   }
 
-  let final_result = result.expect("Failed to run git");
+  let final_result = result.die("Failed to run git", flags);
 
   !final_result.stdout.is_empty()
 }


### PR DESCRIPTION
This pull requests introduces a new `expect`-like method for Result and Option, which has a more human friendly panic when built for release, while still allowing for easy debugging on a debug build.

### How to use
With Results:

```rust
fn some() -> Result<(), &str> {
    Err("Some error")
}

some().die("This error always triggers");
```

With Options:

```rust
fn other() -> Option<u64> {
    Some(9)
}

let variable = other().die("This should not appear");
```

### How it works

The workings of this `die` method are similar to the `expect` method of Results and Options. When running a release build, if the code panics at runtime, instead of directly panicking with the message provided, it prints a nice **ERROR <msg>**, like as shown below (only for demonstration purposes, that does not happen really):
![Screenshot from 2021-05-12 16-02-44](https://user-images.githubusercontent.com/54776315/117988285-8e7e0d00-b33b-11eb-9980-1d50542fbff3.png)
On the other hand, if you are running a debug build, the code panics as if you were using an expect (under the hood it actually calls expect on the Result/Option):
![Screenshot from 2021-05-12 16-05-07](https://user-images.githubusercontent.com/54776315/117988612-ddc43d80-b33b-11eb-9fae-6c62035ff662.png)
Of course, if the Result returns Ok or the Option is Some, it unwraps the value and returns it.

### Inner logic

When running on a Result, it uses `if let Err(_) = self` to check if an error appears, and if it does it prints it to the screen. In case it is not error, it must be Ok, therefore it directly calls `unwrap` on the Result, as it won't fail. For the Option, it uses the same syntax but instead checks for a `None` value, and unwraps if the value is the opposite (`Some`). To print the error, the `ColorExt` trait is taken into scope and used for applying color and boldness to the _ERROR_ &str.

This happens when running on production, on a debug build, it simply wraps expect, calling `self.expect(msg)`.

### `#![allow(unused_imports)]` and `#![allow(unused_variables)]`

Sadly, this two rules are needed. Why? Because rust complains about these with `ColorExt` and the defined trait. The first one, is needed because, even though we are using `ColorExt` for being able to colorize the &str to print, we are not explicitly using it, and therefore rust raises a warning which clippy turns into an error. The second one, is needed because the new `Die` trait does not have a default implementation for the defined `die` method, which takes 2 parameters, which cause rust to raise a warning and clippy to raise an error as they are not used in the trait itself, only in its implementation.

### Limitations and inconveniences

As with any self-defined trait, take `ColorExt` as an example, it has been brought into scope, which mean that it will have to be imported for any script that uses either a Result or an Option (which is most, but this commit already imports the trait for all files which currently use it).

The other downside is that `flags` now travels around all the code. Why so? Because the `ColorExt` trait requires flags to be passed when colorizing an string, the `flags` instance obtained in main has to be passed with any call to `die`, meaning that now methods that did not require flags to be passed to them, now require it.

These two inconveniences are not much of a problem I believe, and they are something with which we will have to deal many times, and so I believe the benefits from the `die` method outnumber the downsides.

A possible solution to the flags problem is to create a new instance of flags inside the `die` method, but that would make it always output color, even if the user adds the `--no-color` flag.

### About the location of the implementation

This is a minor issue, but if the `helper.rs` file does not seem like the best place to put this trait and its implementation, we can find other file. I was thinking of maybe a `prelude.rs` file, where maybe we could also add the `ColorExt` trait, to do `use crate::prelude::*` instead of importing each individually.
