### PR TITLE
Improve `ColorExt`

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -187,7 +187,7 @@ mod tests {
       no_git: false,
     };
 
-    assert_eq!(format!("{}abc{}", CYAN, RESET), format!("{}", "abc".to_owned().cyan(&flags).reset(&flags)));
+    assert_eq!(format!("{}abc{}", CYAN, RESET), format!("{}", "abc".cyan(&flags).reset(&flags)));
   }
 
   #[test]
@@ -200,6 +200,6 @@ mod tests {
       no_git: false,
     };
 
-    assert_eq!("abc", format!("{}", "abc".to_owned().cyan(&flags).reset(&flags)));
+    assert_eq!("abc", format!("{}", "abc".cyan(&flags).reset(&flags)));
   }
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -20,16 +20,66 @@ const GREY: &str = "\x1b[90m";
 const RED: &str = "\x1b[31m";
 
 pub trait ColorExt {
-  fn reset(self, flags: &args::Flags) -> Self;
-  fn bright(self, flags: &args::Flags) -> Self;
-  fn underline(self, flags: &args::Flags) -> Self;
-  fn green(self, flags: &args::Flags) -> Self;
-  fn yellow(self, flags: &args::Flags) -> Self;
-  fn cyan(self, flags: &args::Flags) -> Self;
-  fn white(self, flags: &args::Flags) -> Self;
-  fn grey(self, flags: &args::Flags) -> Self;
-  fn red(self, flags: &args::Flags) -> Self;
-  fn custom(self, color: &str, flags: &args::Flags) -> Self;
+  fn reset(self, _flags: &args::Flags) -> Self
+  where
+    Self: Sized,
+  {
+    self
+  }
+  fn bright(self, _flags: &args::Flags) -> Self
+  where
+    Self: Sized,
+  {
+    self
+  }
+  fn underline(self, _flags: &args::Flags) -> Self
+  where
+    Self: Sized,
+  {
+    self
+  }
+  fn green(self, _flags: &args::Flags) -> Self
+  where
+    Self: Sized,
+  {
+    self
+  }
+  fn yellow(self, _flags: &args::Flags) -> Self
+  where
+    Self: Sized,
+  {
+    self
+  }
+  fn cyan(self, _flags: &args::Flags) -> Self
+  where
+    Self: Sized,
+  {
+    self
+  }
+  fn white(self, _flags: &args::Flags) -> Self
+  where
+    Self: Sized,
+  {
+    self
+  }
+  fn grey(self, _flags: &args::Flags) -> Self
+  where
+    Self: Sized,
+  {
+    self
+  }
+  fn red(self, _flags: &args::Flags) -> Self
+  where
+    Self: Sized,
+  {
+    self
+  }
+  fn custom(self, _color: &str, _flags: &args::Flags) -> Self
+  where
+    Self: Sized,
+  {
+    self
+  }
 }
 
 #[cfg(feature = "color")]
@@ -116,47 +166,7 @@ impl ColorExt for String {
 }
 
 #[cfg(not(feature = "color"))]
-impl ColorExt for String {
-  fn reset(self, _flags: &args::Flags) -> Self {
-    self
-  }
-
-  fn bright(self, _flags: &args::Flags) -> Self {
-    self
-  }
-
-  fn underline(self, _flags: &args::Flags) -> Self {
-    self
-  }
-
-  fn green(self, _flags: &args::Flags) -> Self {
-    self
-  }
-
-  fn yellow(self, _flags: &args::Flags) -> Self {
-    self
-  }
-
-  fn cyan(self, _flags: &args::Flags) -> Self {
-    self
-  }
-
-  fn white(self, _flags: &args::Flags) -> Self {
-    self
-  }
-
-  fn grey(self, _flags: &args::Flags) -> Self {
-    self
-  }
-
-  fn red(self, _flags: &args::Flags) -> Self {
-    self
-  }
-
-  fn custom(self, _color: &str, _flags: &args::Flags) -> Self {
-    self
-  }
-}
+impl ColorExt for String {}
 
 #[cfg(test)]
 mod tests {

--- a/src/color.rs
+++ b/src/color.rs
@@ -20,95 +20,95 @@ const GREY: &str = "\x1b[90m";
 const RED: &str = "\x1b[31m";
 
 pub trait ColorExt {
-  fn reset(&self, flags: &args::Flags) -> Self;
-  fn bright(&self, flags: &args::Flags) -> Self;
-  fn underline(&self, flags: &args::Flags) -> Self;
-  fn green(&self, flags: &args::Flags) -> Self;
-  fn yellow(&self, flags: &args::Flags) -> Self;
-  fn cyan(&self, flags: &args::Flags) -> Self;
-  fn white(&self, flags: &args::Flags) -> Self;
-  fn grey(&self, flags: &args::Flags) -> Self;
-  fn red(&self, flags: &args::Flags) -> Self;
-  fn custom(&self, color: &str, flags: &args::Flags) -> Self;
+  fn reset(self, flags: &args::Flags) -> Self;
+  fn bright(self, flags: &args::Flags) -> Self;
+  fn underline(self, flags: &args::Flags) -> Self;
+  fn green(self, flags: &args::Flags) -> Self;
+  fn yellow(self, flags: &args::Flags) -> Self;
+  fn cyan(self, flags: &args::Flags) -> Self;
+  fn white(self, flags: &args::Flags) -> Self;
+  fn grey(self, flags: &args::Flags) -> Self;
+  fn red(self, flags: &args::Flags) -> Self;
+  fn custom(self, color: &str, flags: &args::Flags) -> Self;
 }
 
 #[cfg(feature = "color")]
 impl ColorExt for String {
-  fn reset(&self, flags: &args::Flags) -> Self {
+  fn reset(self, flags: &args::Flags) -> Self {
     if flags.no_color {
-      self.to_string()
+      self
     } else {
       format!("{}{}", self, String::from(RESET))
     }
   }
 
-  fn bright(&self, flags: &args::Flags) -> Self {
+  fn bright(self, flags: &args::Flags) -> Self {
     if flags.no_color {
-      self.to_string()
+      self
     } else {
       format!("{}{}", String::from(BRIGHT), self)
     }
   }
 
-  fn underline(&self, flags: &args::Flags) -> Self {
+  fn underline(self, flags: &args::Flags) -> Self {
     if flags.no_color {
-      self.to_string()
+      self
     } else {
       format!("{}{}", String::from(UNDERLINE), self)
     }
   }
 
-  fn green(&self, flags: &args::Flags) -> Self {
+  fn green(self, flags: &args::Flags) -> Self {
     if flags.no_color {
-      self.to_string()
+      self
     } else {
       format!("{}{}", String::from(GREEN), self)
     }
   }
 
-  fn yellow(&self, flags: &args::Flags) -> Self {
+  fn yellow(self, flags: &args::Flags) -> Self {
     if flags.no_color {
-      self.to_string()
+      self
     } else {
       format!("{}{}", String::from(YELLOW), self)
     }
   }
 
-  fn cyan(&self, flags: &args::Flags) -> Self {
+  fn cyan(self, flags: &args::Flags) -> Self {
     if flags.no_color {
-      self.to_string()
+      self
     } else {
       format!("{}{}", String::from(CYAN), self)
     }
   }
 
-  fn white(&self, flags: &args::Flags) -> Self {
+  fn white(self, flags: &args::Flags) -> Self {
     if flags.no_color {
-      self.to_string()
+      self
     } else {
       format!("{}{}", String::from(WHITE), self)
     }
   }
 
-  fn grey(&self, flags: &args::Flags) -> Self {
+  fn grey(self, flags: &args::Flags) -> Self {
     if flags.no_color {
-      self.to_string()
+      self
     } else {
       format!("{}{}", String::from(GREY), self)
     }
   }
 
-  fn red(&self, flags: &args::Flags) -> Self {
+  fn red(self, flags: &args::Flags) -> Self {
     if flags.no_color {
-      self.to_string()
+      self
     } else {
       format!("{}{}", String::from(RED), self)
     }
   }
 
-  fn custom(&self, color: &str, flags: &args::Flags) -> Self {
+  fn custom(self, color: &str, flags: &args::Flags) -> Self {
     if flags.no_color {
-      self.to_string()
+      self
     } else {
       format!("{}{}", String::from(color), self)
     }
@@ -117,44 +117,44 @@ impl ColorExt for String {
 
 #[cfg(not(feature = "color"))]
 impl ColorExt for String {
-  fn reset(&self, _flags: &args::Flags) -> Self {
-    self.to_string()
+  fn reset(self, _flags: &args::Flags) -> Self {
+    self
   }
 
-  fn bright(&self, _flags: &args::Flags) -> Self {
-    self.to_string()
+  fn bright(self, _flags: &args::Flags) -> Self {
+    self
   }
 
-  fn underline(&self, _flags: &args::Flags) -> Self {
-    self.to_string()
+  fn underline(self, _flags: &args::Flags) -> Self {
+    self
   }
 
-  fn green(&self, _flags: &args::Flags) -> Self {
-    self.to_string()
+  fn green(self, _flags: &args::Flags) -> Self {
+    self
   }
 
-  fn yellow(&self, _flags: &args::Flags) -> Self {
-    self.to_string()
+  fn yellow(self, _flags: &args::Flags) -> Self {
+    self
   }
 
-  fn cyan(&self, _flags: &args::Flags) -> Self {
-    self.to_string()
+  fn cyan(self, _flags: &args::Flags) -> Self {
+    self
   }
 
-  fn white(&self, _flags: &args::Flags) -> Self {
-    self.to_string()
+  fn white(self, _flags: &args::Flags) -> Self {
+    self
   }
 
-  fn grey(&self, _flags: &args::Flags) -> Self {
-    self.to_string()
+  fn grey(self, _flags: &args::Flags) -> Self {
+    self
   }
 
-  fn red(&self, _flags: &args::Flags) -> Self {
-    self.to_string()
+  fn red(self, _flags: &args::Flags) -> Self {
+    self
   }
 
-  fn custom(&self, _color: &str, _flags: &args::Flags) -> Self {
-    self.to_string()
+  fn custom(self, _color: &str, _flags: &args::Flags) -> Self {
+    self
   }
 }
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use crate::core::*;
 
 #[cfg(feature = "color")]
@@ -20,145 +22,148 @@ const GREY: &str = "\x1b[90m";
 const RED: &str = "\x1b[31m";
 
 pub trait ColorExt {
-  fn reset(self, _flags: &args::Flags) -> Self
+  fn reset(self, _flags: &args::Flags) -> String
   where
-    Self: Sized,
+    Self: Sized + Display,
   {
-    self
+    format!("{}", self)
   }
-  fn bright(self, _flags: &args::Flags) -> Self
+  fn bright(self, _flags: &args::Flags) -> String
   where
-    Self: Sized,
+    Self: Sized + Display,
   {
-    self
+    format!("{}", self)
   }
-  fn underline(self, _flags: &args::Flags) -> Self
+  fn underline(self, _flags: &args::Flags) -> String
   where
-    Self: Sized,
+    Self: Sized + Display,
   {
-    self
+    format!("{}", self)
   }
-  fn green(self, _flags: &args::Flags) -> Self
+  fn green(self, _flags: &args::Flags) -> String
   where
-    Self: Sized,
+    Self: Sized + Display,
   {
-    self
+    format!("{}", self)
   }
-  fn yellow(self, _flags: &args::Flags) -> Self
+  fn yellow(self, _flags: &args::Flags) -> String
   where
-    Self: Sized,
+    Self: Sized + Display,
   {
-    self
+    format!("{}", self)
   }
-  fn cyan(self, _flags: &args::Flags) -> Self
+  fn cyan(self, _flags: &args::Flags) -> String
   where
-    Self: Sized,
+    Self: Sized + Display,
   {
-    self
+    format!("{}", self)
   }
-  fn white(self, _flags: &args::Flags) -> Self
+  fn white(self, _flags: &args::Flags) -> String
   where
-    Self: Sized,
+    Self: Sized + Display,
   {
-    self
+    format!("{}", self)
   }
-  fn grey(self, _flags: &args::Flags) -> Self
+  fn grey(self, _flags: &args::Flags) -> String
   where
-    Self: Sized,
+    Self: Sized + Display,
   {
-    self
+    format!("{}", self)
   }
-  fn red(self, _flags: &args::Flags) -> Self
+  fn red(self, _flags: &args::Flags) -> String
   where
-    Self: Sized,
+    Self: Sized + Display,
   {
-    self
+    format!("{}", self)
   }
-  fn custom(self, _color: &str, _flags: &args::Flags) -> Self
+  fn custom(self, _color: &str, _flags: &args::Flags) -> String
   where
-    Self: Sized,
+    Self: Sized + Display,
   {
-    self
+    format!("{}", self)
   }
 }
 
 #[cfg(feature = "color")]
-impl ColorExt for String {
-  fn reset(self, flags: &args::Flags) -> Self {
+impl<T> ColorExt for T
+where
+  T: std::fmt::Display,
+{
+  fn reset(self, flags: &args::Flags) -> String {
     if flags.no_color {
-      self
+      format!("{}", self)
     } else {
       format!("{}{}", self, String::from(RESET))
     }
   }
 
-  fn bright(self, flags: &args::Flags) -> Self {
+  fn bright(self, flags: &args::Flags) -> String {
     if flags.no_color {
-      self
+      format!("{}", self)
     } else {
       format!("{}{}", String::from(BRIGHT), self)
     }
   }
 
-  fn underline(self, flags: &args::Flags) -> Self {
+  fn underline(self, flags: &args::Flags) -> String {
     if flags.no_color {
-      self
+      format!("{}", self)
     } else {
       format!("{}{}", String::from(UNDERLINE), self)
     }
   }
 
-  fn green(self, flags: &args::Flags) -> Self {
+  fn green(self, flags: &args::Flags) -> String {
     if flags.no_color {
-      self
+      format!("{}", self)
     } else {
       format!("{}{}", String::from(GREEN), self)
     }
   }
 
-  fn yellow(self, flags: &args::Flags) -> Self {
+  fn yellow(self, flags: &args::Flags) -> String {
     if flags.no_color {
-      self
+      format!("{}", self)
     } else {
       format!("{}{}", String::from(YELLOW), self)
     }
   }
 
-  fn cyan(self, flags: &args::Flags) -> Self {
+  fn cyan(self, flags: &args::Flags) -> String {
     if flags.no_color {
-      self
+      format!("{}", self)
     } else {
       format!("{}{}", String::from(CYAN), self)
     }
   }
 
-  fn white(self, flags: &args::Flags) -> Self {
+  fn white(self, flags: &args::Flags) -> String {
     if flags.no_color {
-      self
+      format!("{}", self)
     } else {
       format!("{}{}", String::from(WHITE), self)
     }
   }
 
-  fn grey(self, flags: &args::Flags) -> Self {
+  fn grey(self, flags: &args::Flags) -> String {
     if flags.no_color {
-      self
+      format!("{}", self)
     } else {
       format!("{}{}", String::from(GREY), self)
     }
   }
 
-  fn red(self, flags: &args::Flags) -> Self {
+  fn red(self, flags: &args::Flags) -> String {
     if flags.no_color {
-      self
+      format!("{}", self)
     } else {
       format!("{}{}", String::from(RED), self)
     }
   }
 
-  fn custom(self, color: &str, flags: &args::Flags) -> Self {
+  fn custom(self, color: &str, flags: &args::Flags) -> String {
     if flags.no_color {
-      self
+      format!("{}", self)
     } else {
       format!("{}{}", String::from(color), self)
     }
@@ -166,7 +171,7 @@ impl ColorExt for String {
 }
 
 #[cfg(not(feature = "color"))]
-impl ColorExt for String {}
+impl<T> ColorExt for T where T: std::fmt::Display {}
 
 #[cfg(test)]
 mod tests {

--- a/src/core/help.rs
+++ b/src/core/help.rs
@@ -64,9 +64,9 @@ struct Argument<'a> {
 pub fn print_name_version(flags: &args::Flags) {
   println!(
     "{} {}{}",
-    env!("CARGO_PKG_NAME").to_owned().bright(flags).reset(flags),
-    "v".to_owned().green(flags).reset(flags),
-    env!("CARGO_PKG_VERSION").to_owned().green(flags).reset(flags)
+    env!("CARGO_PKG_NAME").bright(flags).reset(flags),
+    "v".green(flags).reset(flags),
+    env!("CARGO_PKG_VERSION").green(flags).reset(flags)
   );
 }
 
@@ -75,18 +75,12 @@ pub fn print_help(flags: &args::Flags) {
   println!("{}", env!("CARGO_PKG_DESCRIPTION"));
   println!("{}", format!("Created by {}", env!("CARGO_PKG_AUTHORS")).grey(flags).reset(flags));
   println!();
-  println!("{}:", "Usage".to_owned().bright(flags).yellow(flags).reset(flags));
-  println!(
-    "{}{} {}[options] [arguments]{}",
-    INDENT,
-    env!("CARGO_PKG_NAME"),
-    "".to_owned().yellow(flags),
-    "".to_owned().reset(flags)
-  );
+  println!("{}:", "Usage".bright(flags).yellow(flags).reset(flags));
+  println!("{}{} {}[options] [arguments]{}", INDENT, env!("CARGO_PKG_NAME"), "".yellow(flags), "".reset(flags));
 
   for help_section in HELP_SECTIONS {
     println!();
-    println!("{}:", help_section.0.to_owned().bright(flags).yellow(flags).reset(flags));
+    println!("{}:", help_section.0.bright(flags).yellow(flags).reset(flags));
 
     let mut formatted_aliases = vec![];
     let mut max_alias_text_length = 0;
@@ -112,14 +106,14 @@ pub fn print_help(flags: &args::Flags) {
       println!(
         "{}{}{}{}{}{}",
         INDENT,
-        argument.name.unwrap_or("").to_owned().green(flags).reset(flags),
+        argument.name.unwrap_or("").green(flags).reset(flags),
         &formatted_aliases[i].to_string().green(flags).reset(flags),
         (0..max_alias_text_length - formatted_aliases[i].len()).map(|_| " ").collect::<String>(),
         INDENT,
         argument
           .description
-          .replace("[", "[".to_owned().yellow(flags).as_str())
-          .replace("]", "]".to_owned().reset(flags).as_str())
+          .replace("[", "[".yellow(flags).as_str())
+          .replace("]", "]".reset(flags).as_str())
           .reset(flags)
       );
     }

--- a/src/core/help.rs
+++ b/src/core/help.rs
@@ -113,7 +113,7 @@ pub fn print_help(flags: &args::Flags) {
         "{}{}{}{}{}{}",
         INDENT,
         argument.name.unwrap_or("").to_owned().green(flags).reset(flags),
-        formatted_aliases[i].green(flags).reset(flags),
+        &formatted_aliases[i].to_string().green(flags).reset(flags),
         (0..max_alias_text_length - formatted_aliases[i].len()).map(|_| " ").collect::<String>(),
         INDENT,
         argument

--- a/src/die.rs
+++ b/src/die.rs
@@ -15,7 +15,7 @@ where
   fn die(self, msg: &str, flags: &Flags) -> T {
     #[cfg(not(debug_assertions))]
     if let Err(_) = self {
-      println!("{} {}", "ERROR".to_owned().red(flags).bright(flags).reset(flags), msg);
+      println!("{} {}", "ERROR".red(flags).bright(flags).reset(flags), msg);
       std::process::exit(1)
     } else {
       self.unwrap()
@@ -29,7 +29,7 @@ impl<T> Die<T> for Option<T> {
   fn die(self, msg: &str, flags: &Flags) -> T {
     #[cfg(not(debug_assertions))]
     if let None = self {
-      println!("{} {}", "ERROR".to_owned().red(flags).bright(flags).reset(flags), msg);
+      println!("{} {}", "ERROR".red(flags).bright(flags).reset(flags), msg);
       std::process::exit(1)
     } else {
       self.unwrap()

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ fn print_item(root: &path::Path, path: path::PathBuf, flags: &args::Flags, singl
   if !flags.all && file_detection::is_hidden(&path, flags) && !single_item {
     return;
   }
-  let mut color = if path.is_dir() { "".to_owned().cyan(flags) } else { "".to_owned() };
+  let mut color = if path.is_dir() { "".cyan(flags) } else { "".to_owned() };
 
   let mut prefix = String::new();
   let mut name_prefix = String::new();
@@ -63,7 +63,7 @@ fn print_item(root: &path::Path, path: path::PathBuf, flags: &args::Flags, singl
 
   if path.is_file() {
     if item_name.to_lowercase().starts_with("license") {
-      color = "".to_owned().white(&flags);
+      color = "".white(&flags);
       suffix += format!(" [{}]", file_detection::get_license(path.as_path(), flags)).grey(flags).as_str();
     } else {
       color = file_detection::file_extension_color(&path, flags);
@@ -80,9 +80,9 @@ fn print_item(root: &path::Path, path: path::PathBuf, flags: &args::Flags, singl
     if !flags.no_git && modules::git::changed(&final_path, flags) {
       suffix += format!(
         " {}{}{}",
-        "[".to_owned().grey(flags).reset(flags),
-        "M".to_owned().bright(flags).yellow(flags).reset(flags),
-        "]".to_owned().grey(flags).reset(flags)
+        "[".grey(flags).reset(flags),
+        "M".bright(flags).yellow(flags).reset(flags),
+        "]".grey(flags).reset(flags)
       )
       .as_str();
     }
@@ -96,9 +96,9 @@ fn print_item(root: &path::Path, path: path::PathBuf, flags: &args::Flags, singl
     prefix,
     (3..indentation * 3).map(|_| " ").collect::<String>(),
     if indentation > 0 { "└──" } else { "" },
-    if !color.is_empty() { "".to_owned().bright(flags) } else { String::new() },
+    if !color.is_empty() { "".bright(flags) } else { String::new() },
     name_prefix.custom(color.as_str(), flags),
-    item_name.to_owned().reset(flags),
+    item_name.reset(flags),
     suffix,
   );
 }


### PR DESCRIPTION
This pull request improves the current implementation fo the `ColorExt` trait. This pull request resolves #44.

### New trait definition

The trait definition has been updated, changing the function signature and adding default implementations. This was needed for the following sections to properly work. The new signature is:

```rust
pub trait ColorExt {
  fn reset(self, _flags: &args::Flags) -> String
  where
    Self: Sized + Display,
  {
    format!("{}", self)
  }
  /* ... */
}
```

The `Sized` trait is required by the compiler to be able to work with `self`, and the `Display` (`std::fmt::Display`) trait is required to be able to return a `String` by default, by making use of `format!("{}", self)`.

### Use default implementation for no _color_ feature

By adding the default implementations to the trait, we can simplify the implementation for when the _color_ feature is disabled. The implementation can be then simplified to the following single line:

```rust
impl<T> ColorExt for T where T: std::fmt::Display {}
```

### Implement for all types that implement `Display`

Now, any type that implements `std::fmt::Display`, like `&str`, `u8` or even custom types, can be painted with `ColorExt`. In first place, taking ownership of `self` was needed, but it is not needed anymore, although I have not reverted that change, as it does not conflict with any part of the code. In the future, this change could be reverted and instead of getting `self` it could go back to get `&self`.