### PR TITLE
Fix bug when running tree view on `.` or `..`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -144,7 +144,7 @@ fn main() {
   }
 
   let raw_path = args.pop().unwrap_or_else(|| String::from("."));
-  let path_to_scan = path::Path::new(raw_path.as_str());
+  let path_to_scan = &(path::Path::new(raw_path.as_str()).canonicalize().die("Unable to canonicalize path", &flags)).as_path();
 
   if !path_to_scan.exists() {
     println!("File or directory does not exist");


### PR DESCRIPTION
This pull request fixes a simple bug that showed up when running `lsfp -t` without arguments or with a "relative path reference" (_._, _.._, or a combination of those). This bug happened when trying to get the path name with `path.file_name()` in the `file_detection::is_hidden` method.

The solution is fairly simple, just turning the path into an absolute path in the main function before passing it to any other functions. The code that was updated looks like the following:

```rust
147 | let path_to_scan = &(path::Path::new(raw_path.as_str()).canonicalize().die("Unable to canonicalize path", &flags)).as_path();
```

The reason why I add a borrow at the beginning is that `as_path()` takes `&self`, therefore the compiler was giving me issues with calling `as_path()` on a owned value.