### PR TITLE
Improved error message for path canonicalize

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -144,7 +144,7 @@ fn main() {
   }
 
   let raw_path = args.pop().unwrap_or_else(|| String::from("."));
-  let path_to_scan = path::Path::new(raw_path.as_str()).canonicalize().die("Unable to canonicalize path", &flags);
+  let path_to_scan = path::Path::new(raw_path.as_str()).canonicalize().die("Invalid or inexistent path", &flags);
   let path_to_scan = path_to_scan.as_path();
 
   if !path_to_scan.exists() {


### PR DESCRIPTION
The error message provided to `die` when `canonicalize()` is called in the passed was highly complicated to understand, not even I understood it. An error can be raised by this method when the path does not exist, so that is what the message was changed to. It also includes the word _Invalid_ just in case there is some way of messing up with that method by passing a malformed path.