### PR TITLE
Glob patterns

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,7 @@ fn main() {
 
     if !path_to_scan.exists() {
       println!("File or directory does not exist");
-      std::process::exit(0);
+      std::process::exit(1);
     }
 
     if path_to_scan.is_file() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,23 +143,37 @@ fn main() {
     }
   }
 
-  let raw_path = args.pop().unwrap_or_else(|| String::from("."));
-  let path_to_scan = path::Path::new(raw_path.as_str()).canonicalize().die("Invalid or inexistent path", &flags);
-  let path_to_scan = path_to_scan.as_path();
-
-  if !path_to_scan.exists() {
-    println!("File or directory does not exist");
-    std::process::exit(0);
+  if args.is_empty() {
+    args.push(String::from("."));
   }
+  for arg in &args {
+    let path_to_scan = path::Path::new(arg.as_str()).canonicalize().die("Invalid or inexistent path", &flags);
+    let path_to_scan = path_to_scan.as_path();
 
-  if path_to_scan.is_file() {
-    print_item(path_to_scan, path::PathBuf::from(path_to_scan), &flags, true); // Only situation where single_item will be true
-  } else if flags.tree {
-    do_scan(path_to_scan, path_to_scan, &flags);
-  } else {
-    for entry in fs::read_dir(path_to_scan).die("Directory cannot be accessed", &flags) {
-      let path = entry.die("Failed retrieving path", &flags).path();
-      print_item(path_to_scan, path, &flags, false);
+    if !path_to_scan.exists() {
+      println!("File or directory does not exist");
+      std::process::exit(0);
+    }
+
+    if path_to_scan.is_file() {
+      print_item(path_to_scan, path::PathBuf::from(path_to_scan), &flags, true);
+    // Only situation where single_item will be true
+    } else if flags.tree {
+      do_scan(path_to_scan, path_to_scan, &flags);
+    } else {
+      if args.len() > 1 {
+        let newline: &str;
+        if args.iter().position(|a| a == arg).die("Unexpected error when listing directory", &flags) == 0 {
+          newline = "";
+        } else {
+          newline = "\n";
+        }
+        println!("{}", format!("{}Folder {}:", newline, arg).underline(&flags).bright(&flags));
+      }
+      for entry in fs::read_dir(path_to_scan).die("Directory cannot be accessed", &flags) {
+        let path = entry.die("Failed retrieving path", &flags).path();
+        print_item(path_to_scan, path, &flags, false);
+      }
     }
   }
 }


### PR DESCRIPTION
I have finally come with a solution for glob patterns, and is a quite unexpected solution. This resolves #19. Keep in mind that this has only been tested in Linux (I only have _wine_ to test it, and it would not make any sense to test it with _wine_).

Trying to figure out how to make glob patterns work, I made some trials with lsfp itself, and suddenly, I saw that when I did `cargo run -- *`, what was actually being run is `cargo run -- build.rs Cargo.lock Cargo.toml color.c CONTRIBUTING.md LICENSE README.md src target`. So, in that moment a light bulb turned on in my head.

We were trying to make lsfp receive `*`, and then figuring out how to unwrap `*` to `build.rs Cargo.lock Cargo.toml color.c CONTRIBUTING.md LICENSE README.md src target`, but we didn't realize that lsfp never got the `*`. Instead, all terminals, be it DOS or Unix, unwrap the `*` by themselves, `*` is never passed to any program, instead, the terminal resolves those glob patterns and pass multiple arguments to the program.

Taking into account this, implementing glob patterns suddenly became the easiest thing to do. At the moment, lsfp was only scanning one file due to line 146, which took the last argument passed:

```rust
146 | let raw_path = args.pop().unwrap_or_else(|| String::from("."));
```

So, the only thing that needed to be done is simply changing that. Now, instead of taking only the last argument, lsfp repeats the process for each argument, listing each individually and thus enabling multiple arguments and with it glob patters. There a some more little touches to make it work properly or better, which include loading the default path if no argument is passed, printing the directory that is being scanned if there are more files to be also printed and adding a newline at the beginning to all directory listing except if one comes at the very top.

Another minor change was introduced, which is updating the error code with which the process exits from 0 (which stands for success) to 1 (which is a generic error code).