### PR TITLE
Icons (& other optimizations)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,7 @@ readme = "README.md"
 homepage = "https://github.com/The-Noah/lsfp"
 repository = "https://github.com/The-Noah/lsfp"
 license-file = "LICENSE"
-include = [
-  "**/*.rs",
-  "**/*.c",
-  "Cargo.{toml,lock}",
-  "LICENSE",
-]
+include = ["**/*.rs", "**/*.c", "Cargo.{toml,lock}", "LICENSE"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -36,10 +31,11 @@ panic = "abort"
 debug = false
 
 [features]
-default = ["git", "color"]
+default = ["git", "color", "icons"]
 config = []
 git = ["config"]
 color = ["config"]
+icons = ["config"]
 
 [dependencies]
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -192,6 +192,7 @@ mod tests {
       all: false,
       size: false,
       tree: false,
+      icons: false,
       no_color: false,
       no_git: false,
     };
@@ -205,6 +206,7 @@ mod tests {
       all: false,
       size: false,
       tree: false,
+      icons: false,
       no_color: true,
       no_git: false,
     };

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,33 +1,42 @@
-type FileExtensionColor<'a> = (&'a [&'a str], (u8, u8, u8));
+type FileExtensionColor<'a> = (&'a [&'a str], (u8, u8, u8), &'a str);
 
 // https://github.com/ozh/github-colors/blob/master/colors.json
 pub const FILE_EXTENSION_COLORS: &[FileExtensionColor] = &[
-  (&["js"], (241, 224, 90)),                // JavaScript
-  (&["ts"], (43, 116, 137)),                // TypeScript
-  (&["cpp", "cxx", "hpp"], (243, 75, 125)), // C++
-  (&["c", "h"], (85, 85, 85)),              // C
-  (&["yaml", "yml"], (203, 23, 30)),        // YAML
-  (&["json"], (64, 212, 126)),              // JSON
-  (&["rs"], (222, 165, 132)),               // Rust
-  (&["php"], (79, 93, 149)),                // PHP
-  (&["cs"], (23, 134, 0)),                  // C#
-  (&["rb"], (112, 21, 22)),                 // Ruby
-  (&["pl"], (2, 152, 195)),                 // Pearl
-  (&["swift"], (255, 172, 69)),             // Swift
-  (&["md", "markdown"], (8, 63, 161)),      // Markdown
-  (&["py"], (53, 114, 165)),                // Python
-  (&["html", "htm"], (227, 76, 38)),        // HTML
-  (&["css"], (86, 61, 124)),                // CSS
-  (&["scss"], (198, 83, 140)),              // SCSS
-  (&["sass"], (165, 59, 112)),              // SASS
-  (&["less"], (29, 54, 93)),                // Less
-  (&["bat"], (193, 241, 46)),               // Batch
-  (&["ps1", "psm1", "psd1"], (1, 36, 86)),  // Powershell
-  (&["sh"], (137, 224, 81)),                // Shell
-  (&["lua"], (0, 0, 128)),                  // LUA
-  (&["java"], (176, 114, 25)),              // Java
-  (&["m"], (67, 142, 255)),                 // Objective-C
+  (&["js"], (241, 224, 90), "\u{e60c}"),                // JavaScript
+  (&["ts"], (43, 116, 137), "\u{e628}"),                // TypeScript
+  (&["cpp", "cxx", "hpp"], (243, 75, 125), "\u{fb71}"), // C++
+  (&["c", "h"], (85, 85, 85), "\u{e61e}"),              // C (alternative: fb70 [same design as c++'s, but is too big and inconsistent])
+  (&["yaml", "yml"], (203, 23, 30), "\u{e60b}"),        // YAML
+  (&["json"], (64, 212, 126), "\u{e60b}"),              // JSON
+  (&["rs"], (222, 165, 132), "\u{e7a8}"),               // Rust
+  (&["php"], (79, 93, 149), "\u{e73d}"),                // PHP
+  (&["cs"], (23, 134, 0), "\u{f81a}"),                  // C#
+  (&["rb"], (112, 21, 22), "\u{e791}"),                 // Ruby
+  (&["pl"], (2, 152, 195), "\u{f977}"),                 // Pearl (generic script icon, alternatives: `code` icon)
+  (&["swift"], (255, 172, 69), "\u{e755}"),             // Swift
+  (&["md", "markdown"], (8, 63, 161), "\u{f853}"),      // Markdown
+  (&["py"], (53, 114, 165), "\u{e73c}"),                // Python
+  (&["html", "htm"], (227, 76, 38), "\u{e736}"),        // HTML
+  (&["css"], (86, 61, 124), "\u{e74a}"),                // CSS
+  (&["scss"], (198, 83, 140), "\u{e74b}"),              // SCSS
+  (&["sass"], (165, 59, 112), "\u{e74b}"),              // SASS
+  (&["less"], (29, 54, 93), "\u{e758}"),                // Less
+  (&["bat"], (193, 241, 46), "\u{f120}"),               // Batch (generic terminal, alternatives: e795, e7a2)
+  (&["ps1", "psm1", "psd1"], (1, 36, 86), "\u{f489}"),  // Powershell
+  (&["sh"], (137, 224, 81), "\u{f120}"),                // Bash
+  (&["lua"], (0, 0, 128), "\u{e620}"),                  // LUA
+  (&["java"], (176, 114, 25), "\u{e738}"),              // Java
+  (&["m"], (67, 142, 255), "\u{e711}"),                 // Objective-C (generic apple logo)
 ];
+
+#[cfg(feature = "icons")]
+pub const ICON_FOLDER_OPEN: &str = "\u{f115}";
+#[cfg(feature = "icons")]
+pub const ICON_FOLDER_CLOSED: &str = "\u{f114}";
+#[cfg(feature = "icons")]
+pub const ICON_LICENSE: &str = "\u{f623}";
+#[cfg(feature = "icons")]
+pub const ICON_GENERIC: &str = "\u{f723}";
 
 // https://choosealicense.com/
 // https://opensource.org/licenses/

--- a/src/core/args.rs
+++ b/src/core/args.rs
@@ -7,6 +7,8 @@ pub struct Flags {
   pub all: bool,
   pub size: bool,
   pub tree: bool,
+  #[cfg(feature = "icons")]
+  pub icons: bool,
   #[cfg(feature = "color")]
   pub no_color: bool,
   #[cfg(feature = "git")]
@@ -15,12 +17,14 @@ pub struct Flags {
 
 pub fn get() -> (Flags, Vec<String>) {
   let mut args: Vec<String> = std::env::args().collect();
-  args.remove(0); // remove first arguement which is self
+  args.remove(0); // remove first argument which is self
 
   let mut flags = Flags {
     all: false,
     size: false,
     tree: false,
+    #[cfg(feature = "icons")]
+    icons: false,
     #[cfg(feature = "color")]
     no_color: std::env::var("NO_COLOR").is_ok(),
     #[cfg(feature = "git")]
@@ -41,6 +45,8 @@ pub fn get() -> (Flags, Vec<String>) {
       "-a" | "--all" => flags.all = true,
       "-s" | "--size" => flags.size = true,
       "-t" | "--tree" | "-r" | "--recursive" => flags.tree = true,
+      #[cfg(feature = "icons")]
+      "-i" | "--icons" => flags.icons = true,
       #[cfg(feature = "color")]
       "--no-color" => flags.no_color = true,
       #[cfg(feature = "git")]
@@ -74,6 +80,10 @@ pub fn get() -> (Flags, Vec<String>) {
   #[cfg(feature = "color")]
   if !flags.no_color {
     flags.no_color = !config::get_bool("color", true);
+  }
+  #[cfg(feature = "icons")]
+  if !flags.icons {
+    flags.icons = config::get_bool("icons", false);
   }
 
   for (removed_count, arg_to_remove) in args_to_remove.iter().enumerate() {

--- a/src/core/help.rs
+++ b/src/core/help.rs
@@ -31,6 +31,12 @@ const HELP_SECTIONS: &[(&str, &[Argument])] = &[
         aliases: Some(&["t", "r", "tree", "recursive"]),
         description: "Show output as a tree (recursive)",
       },
+      #[cfg(feature = "icons")]
+      Argument {
+        name: None,
+        aliases: Some(&["i", "icons"]),
+        description: "Show icons before filename, requires Nerd Font",
+      },
       #[cfg(feature = "color")]
       Argument {
         name: None,
@@ -45,18 +51,27 @@ const HELP_SECTIONS: &[(&str, &[Argument])] = &[
       },
     ],
   ),
+  #[cfg(feature = "config")]
   (
     "Config",
     &[
+      #[cfg(feature = "color")]
       Argument {
         name: None,
         aliases: Some(&["config-color=<true|false>"]),
         description: "Control colored output",
       },
+      #[cfg(feature = "git")]
       Argument {
         name: None,
         aliases: Some(&["config-git=<true|false>"]),
         description: "Control git integration",
+      },
+      #[cfg(feature = "icons")]
+      Argument {
+        name: None,
+        aliases: Some(&["config-icons=<true|false>"]),
+        description: "Control icons",
       },
     ],
   ),

--- a/src/file_detection.rs
+++ b/src/file_detection.rs
@@ -50,19 +50,26 @@ pub fn get_license(path: &Path, flags: &Flags) -> String {
   license_type.to_string()
 }
 
-pub fn file_extension_color(path: &Path, flags: &Flags) -> String {
-  let mut color = String::new();
-
-  'extension_loop: for extension_color in constants::FILE_EXTENSION_COLORS.iter() {
+pub fn file_extension_styles(path: &Path, flags: &Flags) -> (String, String) {
+  for extension_color in constants::FILE_EXTENSION_COLORS.iter() {
     for extension in extension_color.0 {
       if extension_matches(path, extension, flags) {
-        color = format!("\x1b[38;2;{};{};{}m", extension_color.1 .0, extension_color.1 .1, extension_color.1 .2);
-        break 'extension_loop;
+        return (
+          format!("\x1b[38;2;{};{};{}m", extension_color.1 .0, extension_color.1 .1, extension_color.1 .2,),
+          #[cfg(feature = "icons")]
+          if flags.icons { extension_color.2.to_owned() } else { String::new() },
+          #[cfg(not(feature = "icons"))]
+          String::new(),
+        );
       }
     }
   }
 
-  color
+  #[cfg(feature = "icons")]
+  if flags.icons {
+    return (String::new(), constants::ICON_GENERIC.to_owned());
+  }
+  (String::new(), String::new())
 }
 
 fn extension_matches(path: &Path, extension: &str, flags: &Flags) -> bool {


### PR DESCRIPTION
**This PR closes #47, where the details about icons where discused**

This commit adds icons to lsfp.
It makes use of Nerd Fonts icon aggregation, which makes a bunch of
icons available as unicode characters in a font.
Icons are disabled by default, therefore you need to pass the -i/--icons
flag or set the icons field in a .lsfprc file.
The corresponding option and config help sections were added.

To get icons going, a few modifications to the code were made.
The `file_detection::file_extension_color` function has been changed to
return a tuple, with its first item being the color and the second icon.
The FILE_EXTENSION_COLORS constant has now a third item in its tuples,
which is a string literal with the matching icon escaped unicode.
Other icons (folders, license and generic) have also been added as
constants to `constsants.rs`.
A leading space before the icon and between it and the name has also
been added to improve icons visualization. When running in tree format,
this space is also added between the tree branch and the icon.

Other than the icons, there are some small improvements to the code.
`file_detection::file_extension_styles` has been modified so no mutable
variable is needed and the return type has also been changed, as well as
the name.
The "Config" section of help has also been modified to only show when
the config feature is on, as well as each individual entry inside it.

I used the icons that looked the best to me and fitted better in a terminal environment, but feel free to take a look at the [cheatsheet](https://www.nerdfonts.com/cheat-sheet) and pick other ones if you like them more!