### PR TITLE
Fix underline leak when listing folders on glob

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -213,7 +213,7 @@ fn main() {
         } else {
           newline = "\n";
         }
-        println!("{}", format!("{}Folder {}:", newline, arg).underline(&flags).bright(&flags));
+        println!("{}", format!("{}Folder {}:", newline, arg).underline(&flags).bright(&flags).reset(&flags));
       }
       for entry in fs::read_dir(path_to_scan).die("Directory cannot be accessed", &flags) {
         let path = entry.die("Failed retrieving path", &flags).path();


### PR DESCRIPTION
This PR simply fix the underline style in the folder title when listing multiple items leaking to the next item, due to the miss of the reset flag.