### PR TITLE
Fix _config_ feature required for taking arguments

### DIFF
--- a/src/core/args.rs
+++ b/src/core/args.rs
@@ -58,7 +58,9 @@ pub fn get() -> (Flags, Vec<String>) {
         }
       }
       #[cfg(not(feature = "config"))]
-      _ => {}
+      _ => {
+        continue;
+      }
     }
 
     args_to_remove.push(i);


### PR DESCRIPTION
When disabling the _config_ feature, `lsfp` was not able to take any
argument, and therefore you could only list the current directory.
The problem was simple and straightforward to solve, just a missing
`continue`.
