### PR TITLE
Themes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,16 @@ panic = "abort"
 debug = false
 
 [features]
-default = ["git", "color", "icons"]
-config = []
+default = ["git", "color", "icons", "themes"]
+# End user features
 git = ["config"]
 color = ["config"]
 icons = ["config"]
+themes = ["index_flags", "home"]
+# Internal features
+config = []
+index_flags = []
+home = []
 
 [dependencies]
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -195,6 +195,7 @@ mod tests {
       icons: false,
       no_color: false,
       no_git: false,
+      theme: None,
     };
 
     assert_eq!(format!("{}abc{}", CYAN, RESET), format!("{}", "abc".cyan(&flags).reset(&flags)));
@@ -209,6 +210,7 @@ mod tests {
       icons: false,
       no_color: true,
       no_git: false,
+      theme: None,
     };
 
     assert_eq!("abc", format!("{}", "abc".cyan(&flags).reset(&flags)));

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,42 +1,44 @@
-type FileExtensionColor<'a> = (&'a [&'a str], (u8, u8, u8), &'a str);
+use crate::themes::Theme;
+
+// type FileExtensionColor<'a> = (&'a [&'a str], (u8, u8, u8), &'a str);
 
 // https://github.com/ozh/github-colors/blob/master/colors.json
-pub const FILE_EXTENSION_COLORS: &[FileExtensionColor] = &[
-  (&["js"], (241, 224, 90), "\u{e60c}"),                // JavaScript
-  (&["ts"], (43, 116, 137), "\u{e628}"),                // TypeScript
-  (&["cpp", "cxx", "hpp"], (243, 75, 125), "\u{fb71}"), // C++
-  (&["c", "h"], (85, 85, 85), "\u{e61e}"),              // C (alternative: fb70 [same design as c++'s, but is too big and inconsistent])
-  (&["yaml", "yml"], (203, 23, 30), "\u{e60b}"),        // YAML
-  (&["json"], (64, 212, 126), "\u{e60b}"),              // JSON
-  (&["rs"], (222, 165, 132), "\u{e7a8}"),               // Rust
-  (&["php"], (79, 93, 149), "\u{e73d}"),                // PHP
-  (&["cs"], (23, 134, 0), "\u{f81a}"),                  // C#
-  (&["rb"], (112, 21, 22), "\u{e791}"),                 // Ruby
-  (&["pl"], (2, 152, 195), "\u{f977}"),                 // Pearl (generic script icon, alternatives: `code` icon)
-  (&["swift"], (255, 172, 69), "\u{e755}"),             // Swift
-  (&["md", "markdown"], (8, 63, 161), "\u{f853}"),      // Markdown
-  (&["py"], (53, 114, 165), "\u{e73c}"),                // Python
-  (&["html", "htm"], (227, 76, 38), "\u{e736}"),        // HTML
-  (&["css"], (86, 61, 124), "\u{e74a}"),                // CSS
-  (&["scss"], (198, 83, 140), "\u{e74b}"),              // SCSS
-  (&["sass"], (165, 59, 112), "\u{e74b}"),              // SASS
-  (&["less"], (29, 54, 93), "\u{e758}"),                // Less
-  (&["bat"], (193, 241, 46), "\u{f120}"),               // Batch (generic terminal, alternatives: e795, e7a2)
-  (&["ps1", "psm1", "psd1"], (1, 36, 86), "\u{f489}"),  // Powershell
-  (&["sh"], (137, 224, 81), "\u{f120}"),                // Bash
-  (&["lua"], (0, 0, 128), "\u{e620}"),                  // LUA
-  (&["java"], (176, 114, 25), "\u{e738}"),              // Java
-  (&["m"], (67, 142, 255), "\u{e711}"),                 // Objective-C (generic apple logo)
+pub const DEFAULT_THEME: Theme = &[
+  (&["js"], (241, 224, 90), "e60c"),                // JavaScript
+  (&["ts"], (43, 116, 137), "e628"),                // TypeScript
+  (&["cpp", "cxx", "hpp"], (243, 75, 125), "fb71"), // C++
+  (&["c", "h"], (85, 85, 85), "e61e"),              // C (alternative: fb70 [same design as c++'s, but is too big and inconsistent])
+  (&["yaml", "yml"], (203, 23, 30), "e60b"),        // YAML
+  (&["json"], (64, 212, 126), "e60b"),              // JSON
+  (&["rs"], (222, 165, 132), "e7a8"),               // Rust
+  (&["php"], (79, 93, 149), "e73d"),                // PHP
+  (&["cs"], (23, 134, 0), "f81a"),                  // C#
+  (&["rb"], (112, 21, 22), "e791"),                 // Ruby
+  (&["pl"], (2, 152, 195), "f977"),                 // Pearl (generic script icon, alternatives: `code` icon)
+  (&["swift"], (255, 172, 69), "e755"),             // Swift
+  (&["md", "markdown"], (8, 63, 161), "f853"),      // Markdown
+  (&["py"], (53, 114, 165), "e73c"),                // Python
+  (&["html", "htm"], (227, 76, 38), "e736"),        // HTML
+  (&["css"], (86, 61, 124), "e74a"),                // CSS
+  (&["scss"], (198, 83, 140), "e74b"),              // SCSS
+  (&["sass"], (165, 59, 112), "e74b"),              // SASS
+  (&["less"], (29, 54, 93), "e758"),                // Less
+  (&["bat"], (193, 241, 46), "f120"),               // Batch (generic terminal, alternatives: e795, e7a2)
+  (&["ps1", "psm1", "psd1"], (1, 36, 86), "f489"),  // Powershell
+  (&["sh"], (137, 224, 81), "f120"),                // Bash
+  (&["lua"], (0, 0, 128), "e620"),                  // LUA
+  (&["java"], (176, 114, 25), "e738"),              // Java
+  (&["m"], (67, 142, 255), "e711"),                 // Objective-C (generic apple logo)
 ];
 
 #[cfg(feature = "icons")]
-pub const ICON_FOLDER_OPEN: &str = "\u{f115}";
+pub const ICON_FOLDER_OPEN: &str = "f115";
 #[cfg(feature = "icons")]
-pub const ICON_FOLDER_CLOSED: &str = "\u{f114}";
+pub const ICON_FOLDER_CLOSED: &str = "f114";
 #[cfg(feature = "icons")]
-pub const ICON_LICENSE: &str = "\u{f623}";
+pub const ICON_LICENSE: &str = "f623";
 #[cfg(feature = "icons")]
-pub const ICON_GENERIC: &str = "\u{f723}";
+pub const ICON_GENERIC: &str = "f723";
 
 // https://choosealicense.com/
 // https://opensource.org/licenses/

--- a/src/core/help.rs
+++ b/src/core/help.rs
@@ -49,6 +49,12 @@ const HELP_SECTIONS: &[(&str, &[Argument])] = &[
         aliases: Some(&["no-git"]),
         description: "Do not use git integration",
       },
+      #[cfg(feature = "themes")]
+      Argument {
+        name: None,
+        aliases: Some(&["theme <name|path>"]),
+        description: "Name or path of theme to use.",
+      },
     ],
   ),
   #[cfg(feature = "config")]

--- a/src/file_detection.rs
+++ b/src/file_detection.rs
@@ -5,6 +5,9 @@ use std::path::Path;
 use crate::constants;
 use crate::core::args::Flags;
 use crate::die::Die;
+#[cfg(feature = "icons")]
+use crate::modules::icon;
+use crate::themes::Theme;
 
 #[cfg(target_os = "windows")]
 fn is_hidden_extra(path: &Path, flags: &Flags) -> bool {
@@ -50,14 +53,14 @@ pub fn get_license(path: &Path, flags: &Flags) -> String {
   license_type.to_string()
 }
 
-pub fn file_extension_styles(path: &Path, flags: &Flags) -> (String, String) {
-  for extension_color in constants::FILE_EXTENSION_COLORS.iter() {
+pub fn file_extension_styles(path: &Path, theme: &Theme, flags: &Flags) -> (String, String) {
+  for extension_color in theme.iter() {
     for extension in extension_color.0 {
       if extension_matches(path, extension, flags) {
         return (
           format!("\x1b[38;2;{};{};{}m", extension_color.1 .0, extension_color.1 .1, extension_color.1 .2,),
           #[cfg(feature = "icons")]
-          if flags.icons { extension_color.2.to_owned() } else { String::new() },
+          if flags.icons { icon::from(extension_color.2) } else { String::new() },
           #[cfg(not(feature = "icons"))]
           String::new(),
         );
@@ -67,7 +70,7 @@ pub fn file_extension_styles(path: &Path, flags: &Flags) -> (String, String) {
 
   #[cfg(feature = "icons")]
   if flags.icons {
-    return (String::new(), constants::ICON_GENERIC.to_owned());
+    return (String::new(), icon::from(constants::ICON_GENERIC));
   }
   (String::new(), String::new())
 }

--- a/src/modules/home.rs
+++ b/src/modules/home.rs
@@ -1,0 +1,32 @@
+use std::env;
+use std::path::PathBuf;
+
+/// Get home path. Returns [`None`] if no home path was found.
+///
+/// # Unix
+///
+/// - Returns the value of the 'HOME' environment variable if it is set
+///   (including to an empty string).
+/// - Otherwise, it tries to determine the home directory by invoking the `getpwuid_r` function
+///   using the UID of the current user. An empty home directory field returned from the
+///   `getpwuid_r` function is considered to be a valid value.
+/// - Returns `None` if the current user has no entry in the /etc/passwd file.
+///
+/// # Windows
+///
+/// - Returns value of the 'USERPROFILE' environment variable if it is not empty.
+///
+pub fn home_dir() -> Option<PathBuf> {
+  home_dir_inner()
+}
+
+#[cfg(windows)]
+fn home_dir_inner() -> Option<PathBuf> {
+  env::var_os("USERPROFILE").filter(|s| !s.is_empty()).map(PathBuf::from)
+}
+
+#[cfg(any(unix, target_os = "redox"))]
+fn home_dir_inner() -> Option<PathBuf> {
+  #[allow(deprecated)]
+  env::home_dir()
+}

--- a/src/modules/icon.rs
+++ b/src/modules/icon.rs
@@ -1,0 +1,7 @@
+use crate::constants;
+
+pub fn from(s: &str) -> String {
+  std::char::from_u32(u32::from_str_radix(s, 16).unwrap_or_else(|_| u32::from_str_radix(constants::ICON_GENERIC, 16).unwrap()))
+    .unwrap()
+    .to_string()
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,3 +1,7 @@
 pub mod file_size;
 #[cfg(feature = "git")]
 pub mod git;
+#[cfg(feature = "home")]
+pub mod home;
+#[cfg(feature = "icons")]
+pub mod icon;

--- a/src/themes/README.md
+++ b/src/themes/README.md
@@ -1,0 +1,95 @@
+# Themes for `lsfp`
+
+This module contains support for custom styling in `lsfp`. This custom styling is based on _themes_, which are files that tell `lsfp` what style apply to each extension. You can easily modify and distribute theme files, which can be used by any `lsfp` installation. This file guides you through the path of building a theme file and using it with `lsfp`. In case you are looking for the syntax rules of theme files, read the [formal specification](https://github.com/The-Noah/lsfp/blob/master/src/themes/SPEC.md).
+
+## The theme file syntax
+
+A theme file consists of multiple sections, representing languages and/or extensions that should be styled with the same color or icon. This sections are delimited by a line starting with a dash (`-`), taking the next lines until a new dash. This dash **MUST** be the first character on the line (only leading spaces can be present), but as the line is only used as an indicator of a new section start, everything after that dash is ignored, meaning that you can write as many dashes as you may want or write the language name or some comments on there.
+
+Inside each section, there are different key-value pairs, being the _extensions_ key the most important one, as it is the one that the program will use to recognize files and styles associated. As of today, there are only three keys available, which also depend on the features that you compiled `lsfp` with: **extensions** (primary key which works across al features), **color** (an RGB color for the extensions, only available under _color_ feature) and **icon** (an hexadecimal value made up of 4 characters), only available under _icons_ feature). Keys and values are written as `<key>=<value>` or `<key>:<value>`. All empty lines are ignored, and a key without a value or line that does not match the `<key><:|=><value>` pattern will throw an error, while an unrecognized key will not be of any problem (this ensures full compatibility between binaries compiled with different features).
+
+Here is an example theme file:
+
+```
+--- JS (mjs for modules with node).
+extensions=js,mjs # TODO Add more
+color=255,220,0
+icon=f898
+
+--- TS Maybe there are more extensions?
+extensions=ts
+color=0,31,63
+
+icon=e628 # Don't quite like it
+
+-- IMPORTANT Rust, don't erase this by any means!
+color=255,65,54
+extensions=rs
+icon=e7a8
+```
+
+There is a [formal specification](https://github.com/The-Noah/lsfp/blob/master/src/themes/SPEC.md) which explains in more depth the full syntax for the theme file. In case of any ambiguity, contradiction or doubt, the specification is the absolute source of true. When creating a theme file, it is recommended to first read this specification.
+
+You can also find a test theme file in the root of the repository where the theme parser was first developed, called [test.theme](https://github.com/HipyCas/theme-parser/blob/master/test.theme) (extension is only for easy identification). This theme file is read by the main script for testing purposes, and you may want to try modify it and test it to see how the parser internally works, and test out your scripts.
+
+## Features
+
+Themes in `lsfp` are enabled under the feature _themes_, and therefore if the feature is not enabled for the build, no theme will be parsed/loaded in any case.
+
+For the `colors` and `icon` key the features _color_ and _icons_ (respectively) must be enabled for the build. In case of those not being present, the parser will still give a valid language style, yet the color or icon will be empty and will not be printed by `lsfp` anyway.
+
+In GitHub releases, all builds include all features except `lsfp-lite.exe` (Windows), which includes none. This means that all come with theme support builtin and support for all available settings (except the one mentioned before).
+
+_Themes depend internally in other two features,_ index_flags *and* home, *which should never be manually toggled by the end user.*
+
+## Named themes
+
+When `lsfp` receives a value for the `--theme` flag that is not a path, it will try to load a _named theme_. A _named theme_ is simply a theme file located under `~/.lsfp-themes`, whose name is equivalent to the file name. That way, if you run `lsfp --theme noir` the theme file `~/.lsfp-themes/noir` will be loaded, and if you run `lsfp --theme solarized.dark` the theme file `~/.lsfp-themes/solarized.dark` will be loaded.
+
+File themes do not have an specific extensions neither syntax support in any IDE. That is one of the reasons why `lsfp` loads named themes just by their whole file name, as extension is not important, the whole file name is used.
+
+## Distribution
+
+Theme files are easily distributable. Due to the fact that settings that require a feature to be enabled are ignored by the parser if the feature is not enabled, someone with the _color_ feature and someone without it could be using the same theme file.
+
+`lsfp` provides official themes which you can find in the _themes_ folder (at the crate root, as of now **there are no official themes create**) and distributed as a zip file on GitHub releases next to the built binaries.
+
+## License
+
+Both the code of the theme parser and the specification are distributed under the same license as `lsfp`, as it is part of the program. This license is the MIT license, which allows you to modify and use this parser and specification for both personal and commercial projects, either open source or closed source. See the full LICENSE file at [The-Noah/lsfp](https://github.com/The-Noah/lsfp/blob/master/LICENSE).
+
+## TODO
+
+### Meaningful (impact user experience)
+
+- Allow to set default icon and colors, same as for directories (collapsed and expanded), use `!default`, `!dir_default`, `!dir_open` and `!dir_collapsed`
+
+- Use `;` to separate lines instead of line break
+
+- ~~Allow extra non empty lines as comments, maybe make them start with a `#` or similar~~
+
+- ~~Allow for `:` instead of `=` separator~~
+
+- ~~Make `extensions` key required~~
+
+### DX
+
+- ~~Better error messages, maybe by indicating the line of the error (look at https://llogiq.github.io/2017/06/01/perf-pitfalls.html), use `for (i, line) in text.lines().enumerate() { /* ... */ }`~~
+
+- ~~Return `struct ParseError { line: usize, text: String, error_msg: String }` for Result.Err~~
+
+- Make `ParserError.line` of `Line` type and drop `ParserError.text` attribute
+
+- Make `Line` accept `AsRef<str>` instead of directly `&str` so you can use `String` in `ParserError`
+
+- Return result in `Vec<u8>.as_color()` instead of `(0,0,0)`
+
+- Improve error message ("invalid digit found in string") in lang parser
+
+### Specification
+
+- ~~**IMPORTANT** Formal specification file~~
+
+- Get a better heading than _Pairs_ for SPEC.md <- starting to like _Pairs_
+
+- ~~Update [README.md](https://github.com/HipyCas/theme-parser/blob/master/README.md) to match the specification~~

--- a/src/themes/SPEC.md
+++ b/src/themes/SPEC.md
@@ -1,0 +1,71 @@
+# `lsfp` Theme file specification
+
+This is the formal specification for `lsfp`'s theme file grammar. `lsfp` will only be able to parse files that strictly follow this specification, falling back to the default theme when the file is not of the correct format. For information and usage of theme files inside `lsfp`, see the [theme module README](https://github.com/The-Noah/lsfp/blob/master/src/themes/README.md).
+
+## Sections
+
+A theme file is organized into multiple sections, identified by the `extensions` associated with it. Section start is delimited by a dash (`-`) at the beginning of the line, being everything after the first dash discarded (`lsfp` will not analyze any text after it, you can write anything after the first dahs), and ends with the next line starting by a dash (the next section start delimiter).
+
+Each section contains `key=value` pairs, which are explained in the [Pairs](#Pairs) section. A complete section could be the following (see [Example](#Example) for multiple sections):
+
+```
+--- JS (mjs for modules with node). TODO Add more
+    extensions=js,mjs
+    color=255,220,0
+    icon=f898
+```
+
+All pairs **MUST** be inside a section, meaning that no pair can go at the beginning of the file before the first section, only comments may go before the first section.
+
+## Pairs
+
+The theme styles are indicated in form of `key=value` or `key:value` (both `=` and `:` have the same meaning, equal is used in the examples in this document) pairs inside each section, being `extensions` the primary key (the one that is used for identification by `lsfp`), and the other dependant of `lsfp`'s features. There are three available pairs as of now:
+
+- `extensions`: An array-like of extensions, which should be styled with the styles specified in the section. If this is not specified, the styles in the section will not be applied to any file. The syntax for this key is as follows: `color={ext1},{ext2},{..exts}`, as an example `extensions=js,mjs`.
+
+- `color`: A tuple-like color, indicating the color with which the extensions should be printed. It must be a tuple of 3 numbers, in the range of 0 to 255 included (rust's `u8` type). This configuration is only available if `lsfp` is compiled with the _color_ feature (see [Features in README.md](https://github.com/The-Noah/lsfp/blob/master/src/themes/README.md#Features) for more about features). The syntax for this key is as follows: `color={r},{g},{b}`, as an example `color=255,220,0`.
+
+- `icon`: A four hexadecimal character string representing the icon Unicode code. Icons are supposed to be used with NerdFonts (icons used by default in `lsfp` depend on this font), and you can find a full list of icons and their hexadecimal string on the [NerdFont cheat-sheet](https://www.nerdfonts.com/cheat-sheet); but you may use any form of icon support if it is based in 4 character hexadecimal Unicode value. This configuration is only available if `lsfp` is compiled with the _icons_ feature (see [Features in README.md](https://github.com/The-Noah/lsfp/blob/master/src/themes/README.md#Features) for more about features). The syntax for this key is as follows: `icon={4 chars}`, as an example `icon=f898`.
+
+Short versions of all keys are also available, which are the first letter of the key. That way, `icon=f898` is the same as `i=f898` and `extensions=js,mjs` is the same as `e=js,mjs`.
+
+## Comments
+
+You can write comments by using a hashtag (`#`), both at the beginning of a line or at the end of a pair. Any text in the comment is completely ignored by the parser. For example, the following are both valid comments:
+
+```
+icon=f2a4 # Beautiful solid icon
+# TODO Add color, get some ideas online
+```
+
+Due to the fact that anything in a section delimiter after the first dash is ignored, any text after that first dash can be considered a de facto comment.
+
+## Flexibilities
+
+The parser presents some flexibilities in how you may write values, which are outlined below.
+
+- Leading and trailing commas are ignored in both `color` and `extensions` settings, meaning that both `color=,9,0,12` and `extensions=c,h,o,` are both valid pairs.
+
+- Spaces at beginning and end of lines, keys and values are removed, therefore `<tab|spaces># comment`, `<spaces>icon = f56a <spaces>` and `<spaces>- section<spaces>` are all valid.
+
+## Example
+
+Below is present a full example (a real theme file would be much bigger):
+
+```
+--- JS (mjs for modules with node). TODO Add more
+extensions=js,mjs
+color=255,220,0
+icon=f898
+
+--- TS Maybe there are more extensions? Revise icon
+extensions=ts
+color=0,31,63
+
+icon=e628
+
+-- IMPORTANT Rust, don't erase this by any means!
+color=255,65,54
+extensions=rs
+icon=e7a8
+```

--- a/src/themes/lang.rs
+++ b/src/themes/lang.rs
@@ -1,0 +1,216 @@
+use crate::themes::types::FileStyle;
+use crate::themes::{Color, Line, ParserError, VecConvert};
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Language<'a> {
+  extensions: Vec<String>,
+  extensions_str: Vec<&'a str>,
+  color: Color,
+  icon: String,
+}
+
+impl<'a> Language<'a> {
+  pub const fn new(extensions: Vec<String>, color: Color, icon: String) -> Self {
+    Self {
+      extensions,
+      extensions_str: Vec::new(),
+      color,
+      icon,
+    }
+  }
+
+  pub fn parse(text: &[Line]) -> Result<Language<'a>, ParserError> {
+    let mut extensions = Vec::new();
+    #[cfg(feature = "icons")]
+    let mut color: Vec<u8> = Vec::new();
+    #[cfg(not(feature = "icons"))]
+    let color: Vec<u8> = Vec::new();
+    #[cfg(feature = "icons")]
+    let mut icon: String = String::new();
+    #[cfg(not(feature = "icons"))]
+    let icon: String = String::new();
+
+    for (index, original, (key, value)) in text
+      .iter()
+      .map(|(i, line)| (i, line, line.split_once('#').unwrap_or((line, "")).0)) // Remove inline comments
+      .map(|(i, original, pair)| (i, original, pair.split_once('=').unwrap_or_else(|| pair.split_once(':').unwrap_or(("", "")))))
+      .map(|(i, original, (key, value))| (*i, *original, (key.trim(), value.trim())))
+    {
+      if key.is_empty() && value.is_empty() {
+        return Err(ParserError::new(
+          index,
+          original.to_owned(),
+          format!(
+            "Line must include a pair of key and value separated by a equal (=) in text line \"{key}={value}\" ({key}={value})",
+            key = key,
+            value = value
+          ),
+        ));
+      } else if key.is_empty() {
+        return Err(ParserError::new(index, original.to_owned(), format!("Missing key in text line \"{}={}\"", key, value)));
+      } else if value.is_empty() {
+        return Err(ParserError::new(index, original.to_owned(), format!("Missing value in text line \"{}={}\"", key, value)));
+      } else if key == "e" || key == "extensions" {
+        let mut ext = String::new();
+        for (i, mut ch) in value.char_indices() {
+          if ch == ',' && i == 0 {
+            continue;
+          }
+          if i == value.len() - 1 && ch != ',' {
+            ext.push(ch);
+            ch = ',';
+          }
+          if ch != ',' {
+            ext.push(ch)
+          } else {
+            extensions.push(ext);
+            ext = String::new();
+          }
+        }
+      } else if key == "c" || key == "color" {
+        #[cfg(feature = "color")]
+        {
+          let mut num = String::new();
+          for (i, mut ch) in value.char_indices() {
+            if color.len() >= 3 {
+              return Err(ParserError::new(
+                index,
+                original.to_owned(),
+                "Only 3 numbers (red, green, blue) should be provided for color".to_owned(),
+              ));
+            }
+            if num.len() > 3 {
+              return Err(ParserError::new(index, original.to_owned(), format!("Color must range from 0 to 255, received {}", num)));
+            }
+            if ch == ',' && i == 0 {
+              continue;
+            }
+            if i == value.len() - 1 && ch != ',' {
+              num.push(ch);
+              ch = ',';
+            }
+            if ch != ',' {
+              num.push(ch)
+            } else {
+              color.push(match num.parse() {
+                Ok(num) => num,
+                Err(err) => return Err(ParserError::new(index, original.to_owned(), err.to_string())),
+              });
+              num = String::new();
+            }
+          }
+        }
+      } else if key == "i" || key == "icon" {
+        #[cfg(feature = "icons")]
+        {
+          if value.len() > 4 {
+            return Err(ParserError::new(
+              index,
+              original.to_owned(),
+              format!(
+                "Icon must be 4 characters, 2 hexadecimal values, but found \"{}\", which is {} characters long",
+                value,
+                value.len()
+              ),
+            ));
+          }
+          if !value.chars().all(|c| c.is_digit(16)) {
+            return Err(ParserError::new(
+              index,
+              original.to_owned(),
+              format!("One or more characters in \"{}\" icon are not valid hexadecimal characters", value),
+            ));
+          }
+          icon = value.to_owned()
+        }
+      }
+    }
+
+    if extensions.is_empty() {
+      Err(ParserError::new(
+        text[text.len() - 1].0,
+        text[text.len() - 1].1.to_owned(),
+        "extensions key must be present".to_owned(),
+      ))
+    } else {
+      Ok(Language::new(extensions, color.as_color(), icon))
+    }
+  }
+
+  pub fn as_style(&'a mut self) -> FileStyle {
+    self.extensions_str = self.extensions.iter().map(String::as_str).collect();
+    // self.extensions_str = self.extensions.as_slice();
+    (&self.extensions_str[..], self.color, &self.icon)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn as_vec(text: &str) -> Vec<(usize, &str)> {
+    text.lines().enumerate().collect()
+  }
+
+  mod languages {
+    use super::*;
+
+    #[test]
+    fn js() {
+      assert_eq!(
+        Language::new(vec!["js".to_owned(), "mjs".to_owned()], (255, 220, 0), "f898".to_owned()),
+        Language::parse(&as_vec("extensions=js,mjs\ncolor=255,220,0\nicon=f898")).unwrap()
+      )
+    }
+
+    #[test]
+    fn ts() {
+      assert_eq!(
+        Language::new(vec!["ts".to_owned()], (0, 31, 63), "e628".to_owned()),
+        Language::parse(&as_vec("extensions=ts,\ncolor=0,31,63\nicon=e628")).unwrap()
+      )
+    }
+
+    #[test]
+    fn rs() {
+      assert_eq!(
+        Language::new(vec!["rs".to_owned()], (255, 65, 54), "e7A8".to_owned()),
+        Language::parse(&as_vec("extensions=,rs,\ncolor=255,65,54,\nicon=e7A8")).unwrap()
+      )
+    }
+  }
+
+  mod panic {
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn invalid_line() {
+      Language::parse(&as_vec("-lang\nwrong line with no equal at all")).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn too_long_number() {
+      Language::parse(&as_vec("extensions=,rs,\ncolor=2555,65,54,\nicon=e7A8")).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn too_big_number() {
+      Language::parse(&as_vec("extensions=,rs,\ncolor=458,0,54,\nicon=e7A8")).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn too_many_number() {
+      Language::parse(&as_vec("extensions=,rs,\ncolor=-58,0,54,234,\nicon=e7A8")).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn negative_numbers() {
+      Language::parse(&as_vec("extensions=,rs,\ncolor=458,0,54,\nicon=e7A8")).unwrap();
+    }
+  }
+}

--- a/src/themes/mod.rs
+++ b/src/themes/mod.rs
@@ -1,0 +1,48 @@
+#[cfg(feature = "themes")]
+use std::path::Path;
+
+#[cfg(feature = "themes")]
+use crate::core::args::Flags;
+#[cfg(feature = "home")]
+use crate::modules::home;
+#[cfg(feature = "themes")]
+use crate::Die;
+
+#[cfg(feature = "themes")]
+pub mod lang;
+#[cfg(feature = "themes")]
+mod parser;
+mod types;
+
+#[cfg(feature = "themes")]
+pub use parser::Parser;
+pub use types::{Color, Theme, VecConvert};
+#[cfg(feature = "themes")]
+pub use types::{Line, ParserError};
+
+#[cfg(feature = "themes")]
+pub fn get_theme(name: &Option<String>, flags: &Flags) -> String {
+  #[cfg(feature = "themes")]
+  match name {
+    Some(path) => {
+      let theme_dir = home::home_dir().die("Unable to get home directory", flags).join(".lsfp-themes");
+      if Path::new(&path).exists() && (path.contains('.') || path.contains('/') || path.contains('\\')) {
+        std::fs::read_to_string(&path).die("Unable to read passed file path", flags)
+      } else {
+        let mut text = String::new();
+        if !theme_dir.exists() {
+          std::fs::create_dir(&theme_dir).die("Unable to create theme directory", flags);
+        };
+        for item in std::fs::read_dir(&theme_dir).die("Unable to read theme directory", flags) {
+          if item.die("Unable to unwrap theme directory read result", flags).file_name() == std::ffi::OsString::from(&path) {
+            text = std::fs::read_to_string(&theme_dir.join(&path)).die(&format!("Unable to read named file {}", path), flags)
+          }
+        }
+        text
+      }
+    }
+    None => String::new(),
+  }
+  #[cfg(not(feature = "themes"))]
+  String::new()
+}

--- a/src/themes/parser.rs
+++ b/src/themes/parser.rs
@@ -1,0 +1,94 @@
+use crate::themes::lang::Language;
+use crate::themes::{Line, ParserError};
+
+#[derive(Debug)]
+pub struct Parser {
+  text: String, // iter: std::iter::Peekable<std::str::Chars<'a>>,
+}
+
+impl<'a> Parser {
+  pub fn new(text: String) -> Parser {
+    Parser {
+      text, // iter: text.chars().peekable(),
+    }
+  }
+
+  /*
+  fn next_char(&mut self) -> Option<&char> {
+    self.iter.peek()
+  }
+
+  fn consume_char(&mut self) -> Option<char> {
+    self.iter.next()
+  }
+
+  fn consume_while<F>(&mut self, test_fun: F) -> String
+  where
+    F: Fn(&char) -> bool,
+  {
+    let mut result = String::new();
+    while !self.next_char().is_none() && test_fun(self.next_char().unwrap_or(&' ')) {
+      result.push(self.consume_char().unwrap());
+    }
+    result
+  }
+
+  fn consume_whitespace(&mut self) {
+    self.consume_while(|c| c.is_whitespace());
+  }
+
+  fn consume_until_newline(&mut self) -> String {
+    let res = self.consume_while(|c| c != &'\n' && c != &'\r');
+    self.consume_char();
+    res
+  }
+
+  fn consume_ascii(&mut self) -> String {
+    self.consume_while(|c| c.is_ascii())
+  }
+  */
+
+  pub fn parse(self) -> Result<Vec<Language<'a>>, ParserError> {
+    let mut split = self.text.as_str().lines().enumerate();
+
+    let mut section_started = false;
+
+    // let mut reading_lang = false;
+    let mut langs = Vec::<Language>::new();
+    let mut lang = Vec::<Line<'a>>::new();
+
+    loop {
+      let option = split.next();
+      let (index, line) = match option {
+        Some(opt) => (opt.0 + 1, Some(opt.1)),
+        None => (0, None),
+      };
+      if line.is_none() || line.unwrap_or_default().trim_start().starts_with('-') {
+        section_started = true;
+        if !lang.is_empty() {
+          langs.push(Language::parse(lang.as_slice())?);
+        }
+        lang = Vec::new();
+        // reading_lang = false;
+        if line.is_none() {
+          break;
+        } else {
+          continue;
+        }
+      }
+      let line = line.unwrap().trim();
+      if !line.is_empty() && !line.starts_with('#') {
+        if !section_started {
+          return Err(ParserError::new(
+            index,
+            line.to_owned(),
+            "Expected file to start with section or comment, instead pair was found".to_owned(),
+          ));
+        }
+        lang.push((index, line))
+      }
+    }
+
+    Ok(langs)
+  }
+}

--- a/src/themes/types.rs
+++ b/src/themes/types.rs
@@ -1,0 +1,46 @@
+#[cfg(feature = "themes")]
+use std::{error, fmt};
+
+pub type Color = (u8, u8, u8);
+
+pub type FileStyle<'a> = (&'a [&'a str], Color, &'a str);
+
+pub type Theme<'a> = &'a [FileStyle<'a>];
+
+pub trait VecConvert {
+  fn as_color(&self) -> Color;
+}
+
+impl VecConvert for Vec<u8> {
+  fn as_color(&self) -> Color {
+    (*self.get(0).unwrap_or(&0), *self.get(1).unwrap_or(&0), *self.get(2).unwrap_or(&0))
+  }
+}
+
+#[cfg(feature = "themes")]
+pub type Line<'a> = (usize, &'a str);
+
+#[cfg(feature = "themes")]
+#[derive(Debug)]
+pub struct ParserError {
+  line: usize,
+  text: String,
+  msg: String,
+}
+
+#[cfg(feature = "themes")]
+impl ParserError {
+  pub fn new(line: usize, text: String, msg: String) -> ParserError {
+    ParserError { line, text, msg }
+  }
+}
+
+#[cfg(feature = "themes")]
+impl fmt::Display for ParserError {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    f.write_str(&format!("parser error on line {} with contents \"{}\": {}", self.line, self.text, self.msg.to_lowercase()))
+  }
+}
+
+#[cfg(feature = "themes")]
+impl error::Error for ParserError {}


### PR DESCRIPTION
This commit implements themes, discussed in issue #56.
It brings the parser created aside in the repository
[HipyCas/theme-parser](https://github.com/HipyCas/theme-parser) and
adapts it to the project.
Themes are passed using the `--theme` flag followed by the name or path.
For more information, read the [README.md of the `themes`
module](https://github.com/The-Noah/lsfp/blob/master/src/themes/README.md)
or for theme file syntax the [formal
specification](https://github.com/The-Noah/lsfp/blob/master/src/themes/SPEC.md).

**Features**

With this addition, three new features where added.
The feature that enables themes is _themes_, that at the same time depend on other features.
The pairs that get parsed in the theme file depend at the same time on which other
features are enabled (_color_ and _icons_).
Other two features added which are only for internal use, in which _themes_ depends, are _home_ (adds
function to get home directory) and _index_flags_ (enables indexing of
`lsfp::core::args::Flags`).

**Named themes**

`lsfp` can load a theme by its name or by path. To load a specific path
make sure that it exists and includes either a dot or a forward or
backward slash.
When loading a theme by name, `lsfp` looks for a file named like the
passed name under `~/.lsfp-themes`.

**Isues**
- Closes #56