### PR TITLE
Chainable single letter flags

### DIFF
--- a/src/core/args.rs
+++ b/src/core/args.rs
@@ -45,8 +45,16 @@ impl IndexMut<&'_ str> for Flags {
 }
 
 pub fn get() -> (Flags, Vec<String>) {
-  let mut args: Vec<String> = std::env::args().collect();
-  args.remove(0); // remove first argument which is self
+  let mut args: Vec<String> = std::env::args()
+    .skip(1) // remove first argument which is self
+    .flat_map(|arg: String| {
+      if arg.starts_with('-') && arg.get(1..2) != Some("-") && arg.get(1..).map(|text| text.len()) > Some(1) {
+        arg.chars().skip(1).map(|c: char| format!("-{}", c)).collect::<Vec<String>>()
+      } else {
+        vec![arg]
+      }
+    })
+    .collect();
 
   let mut flags = Flags {
     all: false,


### PR DESCRIPTION
This PR brings what I've called _chainable single letter flags_, i.e. being able to chaing single letter options/flags into the same one instead of having to list them individually. This PR relation to issues: closes #45.

### What you can do now

Before, for passing various options/flags, you would have to write each one individually, like so:

```sh
lsfp -a -t -s -i
```

With this changes, you could now write it in a shorter form, showing the same result:

```sh
lsfp -atsi
```

Keep in mind, this **does not work with long versions of flags** (or flags which only have long versions). Therefore, the following wouldn't work:

```sh
lsfp -atree  # would actually be interpreted like `lsfp -a -t -r -e -e`
lsfp -a-tree  # like `lsfp -a -- -t -r -e -e`
lsfp --alltree  # in no case starting by two dashes works
```

### How it is coded

The new code makes use of iterator methods, using the `skip` (although this one not for the actual chainable flags stuff) and `flat_map` (combination of `flatten` and `map`). This is how the closure in the `flat_map` method looks like:

```rs
let mut args = ....flat_map(|arg: String| {
      if arg.starts_with("-") && arg.get(1..2) != Some("-") && arg.get(1..).map(|text| text.len()) > Some(1) {
        arg.chars().skip(1).map(|c: char| format!("-{}", c)).collect::<Vec<String>>()
      } else {
        vec![arg].into_iter().collect::<Vec<String>>()
      }
    })...
```

`arg.starts_with("-")` ensures that we are actually looking at an option and not positional argument, `arg.get(1..2) != Some("-")` checks that the second character is not another dash and therefore not a long form flag and finally `arg.get(1..).map(|text| text.len()) > Some(1)` makes sure that there are at least two other letters after the dash (wouldn't make much sense to process just one flag as many, although it would work with this code).
In case some of those checks fails, it means that we are not looking at two short options chained together, so it just returns the argument as a String vector.