### PR TITLE
`args_to_remove` optimization and no listing when setting config

### DIFF
--- a/src/core/args.rs
+++ b/src/core/args.rs
@@ -70,7 +70,7 @@ pub fn get() -> (Flags, Vec<String>) {
     theme: None,
   };
 
-  let mut args_to_remove = vec![];
+  let mut args_to_remove = Vec::with_capacity(args.len());
 
   let mut print_help = false;
   let mut print_version = false;
@@ -107,6 +107,8 @@ pub fn get() -> (Flags, Vec<String>) {
       _ => {
         if !config::parse_arg(arg, &flags) {
           continue;
+        } else {
+          std::process::exit(0);
         }
       }
       #[cfg(not(feature = "config"))]

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -15,7 +15,7 @@ pub fn parse_arg(arg: &str, flags: &Flags) -> bool {
       let name = parts[0];
       let value = parts[1];
 
-      println!("set {}={}\n", name, value);
+      println!("set {}={}", name, value);
       let content_split = match fs::read_to_string(CONFIG_NAME) {
         Ok(x) => x,
         Err(_) => {


### PR DESCRIPTION
This small PR introduces two small tweaks mentioned in issues earlier, thus closes #61 and closes #51.

### `args_to_remove` optimization

The only file touched for this is `core/args.rs`, as it is a single line improvement. As mentioned in issue #61, the optimized code is as follows:

```rs
let mut args_to_remove = Vec::with_capacity(args.len());
```

### No listing when setting config

As discussed in issue #51, `lsfp` should not run its normal behaviour (listing) when setting a configuration value via the CLI option (`--config-<key>=<value>`). This PR introduces this, by exiting the program with code 0 (success) when configuration is successfully written. Also a newline that was printed before for extra spacing between configuration message and listing was removed.